### PR TITLE
Bugfix: rendering element type='hidden'

### DIFF
--- a/widgets/TbForm.php
+++ b/widgets/TbForm.php
@@ -4,112 +4,111 @@
  *
  * Support for Yii formbuilder
  * @link http://www.yiiframework.com/doc/guide/1.1/en/form.builder
+ * @author Joe Blocher <yii@myticket.at>
+ * @copyright Copyright &copy; Joe Blocher 2012
+ * @license http://www.opensource.org/licenses/bsd-license.php New BSD License
+ * @package bootstrap.widgets
  *
  * Usage:
  *
  * 1. Create a CForm model
  *
 
-
 class FormbuilderTestModel extends CFormModel
 {
-public $search;
-public $agree;
-public $radiolist;
+    public $search;
+    public $agree;
+    public $radiolist;
 
-public function rules()
-{
-return array(
-array('search', 'required'),
-array('agree,radiolist', 'boolean'),
-array('agree', 'compare', 'compareValue' => true,
-'message' => 'You must agree...'),
+    public function rules()
+    {
+        return array(
+            array('search', 'required'),
+            array('agree,radiolist', 'boolean'),
+            array('agree', 'compare', 'compareValue' => true,
+                'message' => 'You must agree...'),
 
-);
-}
+        );
+    }
 
-// Change the labels here
-public function attributeLabels()
-{
-return array(
-'search'=>'Text search',
-'selectlist'=>'I agree',
-);
-}
+    // Change the labels here
+    public function attributeLabels()
+    {
+        return array(
+            'search' => 'Text search',
+            'selectlist' => 'I agree',
+        );
+    }
 
-// return the formbuilder config
-public function getFormConfig()
-{
-array(
-'title' => 'Formbuilder test form',
-'showErrorSummary' => true,
-'elements' => array(
-'search' => array(
-'type' => 'text',
-'maxlength' => 32,
-'hint' => 'This is a hint',
-'placeholder' => 'title',
-'class' => 'input-large',
-'append' => '<i class="icon-search"></i>',
+    // return the formbuilder config
+    public function getFormConfig()
+    {
+        array(
+            'title' => 'Formbuilder test form',
+            'showErrorSummary' => true,
+            'elements' => array(
+                'search' => array(
+                    'type' => 'text',
+                    'maxlength' => 32,
+                    'hint' => 'This is a hint',
+                    'placeholder' => 'title',
+                    'class' => 'input-large',
+                    'append' => '<i class="icon-search"></i>',
 
-'agree' => array(
-'type' => 'checkbox',
-// 'hint' => 'Agree to terms and conditions',
-),
+                    'agree' => array(
+                        'type' => 'checkbox',
+                    // 'hint' => 'Agree to terms and conditions',
+                    ),
 
-'radiolist' => array(
-'type' => 'radiolist',
-'items' => array('item1' => '1', 'item2' => '2', 'item3' => '3'),
-),
-),
+                    'radiolist' => array(
+                        'type' => 'radiolist',
+                        'items' => array('item1' => '1', 'item2' => '2', 'item3' => '3'),
+                    ),
+                ),
 
-'buttons' => array(
-'submit' => array(
-'type' => 'submit', //@see TbFormButtonElement::$TbButtonTypes
-'layoutType' => 'primary', //@see TbButton->type
-'label' => 'Submit',
-),
-'reset' => array(
-'type' => 'reset',
-'label' => 'Reset',
-),
-),
-)
-);
-}
+                'buttons' => array(
+                    'submit' => array(
+                        'type' => 'submit', //@see TbFormButtonElement::$TbButtonTypes
+                        'layoutType' => 'primary', //@see TbButton->type
+                        'label' => 'Submit',
+                    ),
+                    'reset' => array(
+                        'type' => 'reset',
+                        'label' => 'Reset',
+                    ),
+                ),
+            )
+        );
+    }
+
  *
  * 2. Create a testaction in the controller
  *
  * Check TbFormInputElement::$tbActiveFormMethods for available types
  *
-public function actionFormbuilderTest()
-{
-$model = new FormbuilderTestModel;
 
-if(isset($_POST['FormbuilderTestModel']))
-$model->attributes = $_POST['FormbuilderTestModel'];
+    public function actionFormbuilderTest()
+    {
+        $model = new FormbuilderTestModel;
 
-$model->validate();
+        if (isset($_POST['FormbuilderTestModel']))
+            $model->attributes = $_POST['FormbuilderTestModel'];
 
-$form = TbForm::createForm($model->getFormConfig(),$model,
-array( //@see TbActiveForm attributes
-'htmlOptions'=>array('class'=>'well'),
-'type'=>'horizontal', //'inline','horizontal','vertical'
-...
-)
-);
+        $model->validate();
 
-//no need for an extra view file for testing
-$this->renderText($form);
-//$this->render('formbuildertest',array('form'=>$form);
-}
- *
- *
- *
- * @author Joe Blocher <yii@myticket.at>
- * @copyright Copyright &copy; Joe Blocher 2012
- * @license http://www.opensource.org/licenses/bsd-license.php New BSD License
- * @package bootstrap.widgets
+        $form = TbForm::createForm($model->getFormConfig(), $model,
+        array( //@see TbActiveForm attributes
+            'htmlOptions' => array('class' => 'well'),
+            'type' => 'horizontal', //'inline','horizontal','vertical'
+        ...
+        )
+        );
+
+    //no need for an extra view file for testing
+    $this->renderText($form);
+    //$this->render('formbuildertest',array('form'=>$form);
+    }
+
  */
 
 class TbForm extends CForm
@@ -155,7 +154,7 @@ class TbForm extends CForm
         if ($element instanceof TbFormInputElement)
         {
             if ($element->type === 'hidden')
-                return "<div style=\"visibility:hidden\">\n".$element->renderInput()."</div>\n";
+                return "<div style=\"visibility:hidden\">\n" . $element->renderInput() . "</div>\n";
             else
                 return $element->render();
         }


### PR DESCRIPTION
Have to handle hidden elements in TbForm too, because parent::renderElement renders a invisible bootstrap row with control-tags. 

The fixed problem: A invisible full bootstrap-control-row has a visible height.
