### PR TITLE
Removed app->end. Example is a function in controller named afterAction(...

### DIFF
--- a/actions/TbSortableAction.php
+++ b/actions/TbSortableAction.php
@@ -41,7 +41,6 @@ class TbSortableAction extends CAction
             }
             $query .= 'END WHERE sort_order IN (' . implode(',', $ids) . ');';
             Yii::app()->db->createCommand($query)->execute();
-            Yii::app()->end();
         } else {
             throw new CHttpException(500, Yii::t('yii', 'Your request is invalid.'));
         }


### PR DESCRIPTION
...$action), which in the presence of app->end will not run.

My example and problem: 
when i resort menu items and save it, menu cache not updated. I use 

``` php
    protected function afterAction($action)
    {
        if ($action->id == 'sortable') {
            ... cache->update ...
```
