### PR TITLE
Fix bug

### DIFF
--- a/widgets/TbRedactorJs.php
+++ b/widgets/TbRedactorJs.php
@@ -68,7 +68,7 @@ class TbRedactorJS extends CInputWidget
 		Yii::app()->bootstrap->registerAssetCss('redactor.css');
 		Yii::app()->bootstrap->registerAssetJs('redactor.min.js');
 
-		$options = CJSON::encode(CMap::mergeArray($this->editorOptions, array('lang' => $this->lang)));
+		$options = CMap::mergeArray($this->editorOptions, array('lang' => $this->lang));
 
 		Yii::app()->bootstrap->registerRedactor('#'.$id, $options);
 	}


### PR DESCRIPTION
In the "Yii::app()->bootstrap->registerRedactor" already exists "CJavaScript::encode($options)"
