### PR TITLE
renderKeys() in TbExtendedGridView.php

### DIFF
--- a/widgets/TbExtendedGridView.php
+++ b/widgets/TbExtendedGridView.php
@@ -247,7 +247,7 @@ class TbExtendedGridView extends TbGridView
 			'title'=>Yii::app()->getRequest()->getUrl(),
 		));
 		foreach($data as $d)
-			echo CHtml::tag('span',array('data-order' => $this->getAttribute($d, $this->sortableAttribute), CHtml::encode($this->getPrimaryKey($d))));
+   			echo CHtml::tag('span',array('data-order' => $this->getAttribute($d, $this->sortableAttribute), ), CHtml::encode($this->getPrimaryKey($d)));
 		echo "</div>\n";
 	}
 


### PR DESCRIPTION
small mistake in renderKeys(). Last data should go to span's value, instead of attr.
