### PR TITLE
Fix #165 - Tbfileupload passing variable name by render.

### DIFF
--- a/widgets/TbFileUpload.php
+++ b/widgets/TbFileUpload.php
@@ -111,7 +111,7 @@ class TbFileUpload extends CJuiInputWidget
 
 		$this->render($this->uploadView);
 		$this->render($this->downloadView);
-		$this->render($this->formView, compact('htmlOptions'));
+    $this->render($this->formView, array('name'=>$name, 'htmlOptions'=>$this->htmlOptions)); 
 
 		if ($this->previewImages || $this->imageProcessing)
 		{


### PR DESCRIPTION
Following the last PM. I could fix the name bug.
