### PR TITLE
Update widgets/TbFileUpload.php

### DIFF
--- a/widgets/TbFileUpload.php
+++ b/widgets/TbFileUpload.php
@@ -102,6 +102,29 @@ class TbFileUpload extends CJuiInputWidget
 
 		$this->options['url'] = $this->url;
 
+		// if acceptFileTypes is not set as option, try getting it from models rules
+		if(!isset($this->options['acceptFileTypes']))
+		{
+			$fileTypes = $this->getFileValidatorProperty($this->model, $this->attribute, 'types');
+
+			if(isset($fileTypes))
+			{
+				$fileTypes = (preg_match(':jpg:', $fileTypes) && !preg_match(':jpe:', $fileTypes) ? preg_replace(':jpg:','jpe?g',$fileTypes) : $fileTypes);
+				$this->options['acceptFileTypes'] = 'js:/(\.)('.preg_replace(':,:', '|', $fileTypes).')$/i';
+			}
+		}
+
+		// if maxFileSize is not set as option, try getting it from models rules
+		if(!isset($this->options['maxFileSize']))
+		{
+			$fileSize = $this->getFileValidatorProperty($this->model, $this->attribute, 'maxSize');
+
+			if(isset($fileSize))
+			{
+				$this->options['maxFileSize'] = $fileSize;
+			}
+		}
+
 		$htmlOptions = array();
 
 		if ($this->multiple)
@@ -111,7 +134,7 @@ class TbFileUpload extends CJuiInputWidget
 
 		$this->render($this->uploadView);
 		$this->render($this->downloadView);
-    $this->render($this->formView, array('name'=>$name, 'htmlOptions'=>$this->htmlOptions)); 
+    		$this->render($this->formView, array('name'=>$name, 'htmlOptions'=>$this->htmlOptions)); 
 
 		if ($this->previewImages || $this->imageProcessing)
 		{
@@ -166,4 +189,23 @@ class TbFileUpload extends CJuiInputWidget
 		Yii::app()->clientScript->registerScript(__CLASS__ . '#' . $id, "jQuery('#{$id}').fileupload({$options});");
 	}
 
+	/**
+	 * Check for a property of CFileValidator
+	 * @param $model
+	 * @param $attribute
+	 * @return string property's value or null
+	 */
+	private function getFileValidatorProperty($model=null, $attribute=null, $property=null)
+	{
+		if(!isset($model,$attribute,$property)) return null;
+
+		foreach($model->getValidators($attribute) as $validator)
+		{
+			if($validator instanceof CFileValidator)
+			{
+		        	$ret = $validator->$property;
+			}
+		}
+		return isset($ret) ? $ret : null;
+	}
 }


### PR DESCRIPTION
if the options (acceptedFileTypes and maxFileSize) are not set via the widget call; the widget will check in the model's validation rules.

few comments:
- no need to do further check if model/attribute exists as it's done by $this->resolveNameID();
- one could have shorten the syntax a bit but i do prefer the clean and more readable approach
- vice versa? i don't think it's necessary to add these option to the model's validation (if set via widget and not set in rules) as validation will mainly and first be done by the widget; besides the acceptedFileTypes value can/is a regex; of course it can be processed... but it seems to be too much ado about...

as it is right now, one can set the rules in model and/or the widget

last not least, in case fileSize is not set on either side, one could get the maximum size allowed per upload from php.ini.... let me know.
