### PR TITLE
Fix for placeholder overwriting in TbInputInline and TbInputSearch

### DIFF
--- a/widgets/input/TbInputInline.php
+++ b/widgets/input/TbInputInline.php
@@ -31,7 +31,7 @@ class TbInputInline extends TbInputVertical
 	 */
 	protected function passwordField()
 	{
-		$this->htmlOptions['placeholder'] = $this->model->getAttributeLabel($this->attribute);
+		$this->setPlaceholder();
 		echo $this->getPrepend();
 		echo $this->form->passwordField($this->model, $this->attribute, $this->htmlOptions);
 		echo $this->getAppend();
@@ -43,7 +43,7 @@ class TbInputInline extends TbInputVertical
 	 */
 	protected function textArea()
 	{
-		$this->htmlOptions['placeholder'] = $this->model->getAttributeLabel($this->attribute);
+		$this->setPlaceholder();
 		echo $this->form->textArea($this->model, $this->attribute, $this->htmlOptions);
 	}
 
@@ -53,9 +53,17 @@ class TbInputInline extends TbInputVertical
 	 */
 	protected function textField()
 	{
-		$this->htmlOptions['placeholder'] = $this->model->getAttributeLabel($this->attribute);
+		$this->setPlaceholder();
 		echo $this->getPrepend();
 		echo $this->form->textField($this->model, $this->attribute, $this->htmlOptions);
 		echo $this->getAppend();
+	}
+
+	protected function setPlaceholder()
+	{
+		if (empty($this->htmlOptions['placeholder']))
+		{
+			$this->htmlOptions['placeholder'] = $this->model->getAttributeLabel($this->attribute);
+		}
 	}
 }

--- a/widgets/input/TbInputSearch.php
+++ b/widgets/input/TbInputSearch.php
@@ -26,7 +26,7 @@ class TbInputSearch extends TbInputInline
 		else
 			$this->htmlOptions['class'] = 'search-query';
 
-		$this->htmlOptions['placeholder'] = $this->model->getAttributeLabel($this->attribute);
+		$this->setPlaceholder();
 		echo $this->getPrepend();
 		echo $this->form->textField($this->model, $this->attribute, $this->htmlOptions);
 		echo $this->getAppend();


### PR DESCRIPTION
When configuring `TbInputSearch` and `TbInputInline` the custom placeholder which you write in `htmlOptions['placeholder']` gets overwritten by the attribute label.

This commit will fix this behavior: placeholder will be set to attribute label only when it's not set to anything.

This is fix for #211 
