### PR TITLE
Add option to disable asset publication in debug mode.

### DIFF
--- a/components/Bootstrap.php
+++ b/components/Bootstrap.php
@@ -98,6 +98,14 @@ class Bootstrap extends CApplicationComponent
 	public $enableNotifierJS = true;
 
 	/**
+	 * @var bool|null Whether to republish assets on each request. Defaults to YII_DEBUG, resulting in a the republication of all YiiBooster-assets 
+	 * on each request if the application is in debug mode. Passing null to this option restores 
+	 * the default handling of CAssetManager of YiiBooster assets.
+	 * @since YiiBooster 1.0.6
+	 */
+	public $republishAssetsOnRequest = YII_DEBUG;
+	
+	/**
 	 * @var string handles the assets folder path.
 	 */
 	protected $_assetsUrl;
@@ -507,7 +515,7 @@ class Bootstrap extends CApplicationComponent
 		else
 		{
 			$assetsPath = Yii::getPathOfAlias('bootstrap.assets');
-			$assetsUrl = Yii::app()->assetManager->publish($assetsPath, false, -1, YII_DEBUG);
+			$assetsUrl = Yii::app()->assetManager->publish($assetsPath, false, -1, $this->republishAssetsOnRequest);
 			return $this->_assetsUrl = $assetsUrl;
 		}
 	}


### PR DESCRIPTION
Since beeing in debug mode (YII_DEBUG === true) doesn't imply that there is a need to republish the assets on each request, it would be nice to have an option to disable this handling. Time to time it is annoying having to wait several seconds before a simple change (wich is not layout related) is visible (data related)

BC: good (YII_DEBUG is still used as default value, if user decides not to use this option, nothing has changed)

Usecase:
- Any development which is not YiiBooster related.
  - Such as work on Models or bare controller.
