### PR TITLE
Visibility property for TbButton

### DIFF
--- a/widgets/TbButton.php
+++ b/widgets/TbButton.php
@@ -112,6 +112,12 @@ class TbButton extends CWidget
 	public $dropdownOptions = array();
 
 	/**
+	 * @var whether the button is visible or not
+	 * @since 0.9.11
+	 */
+	public $visible = true;
+
+	/**
 	 * Initializes the widget.
 	 */
 	public function init()
@@ -188,6 +194,8 @@ class TbButton extends CWidget
 	 */
 	public function run()
 	{
+		if(!$this->visible)
+				return false;
 		echo $this->createButton();
 
 		if ($this->hasDropdown())


### PR DESCRIPTION
I just thought it might be quite a tidy thing to have a visible property on the TbButton class, so you could easily hide and unhide buttons based on roles etc for a particular button.

you could thus have something like:

``` php
<?php $this->widget('bootstrap.widgets.TbButton',array(
                'label' => 'Widget Report',
                'type' => 'success',
                'size' => 'medium',
                'url'  =>  $this->createUrl('affiliate/widgetreport',array('id'=>$data->id)),
                'visible'=>Yii::app()->user->checkAccess('manageWidgets'),
));?>
```
