### PR TITLE
Improved support of CActiveForm::error method for input widgets.

### DIFF
--- a/widgets/input/TbInput.php
+++ b/widgets/input/TbInput.php
@@ -94,6 +94,18 @@ abstract class TbInput extends CInputWidget
 	 * @var array captcha html attributes.
 	 */
 	public $captchaOptions = array();
+	/**
+	 * This property allows you to disable AJAX valiadtion for certain fields within a form.
+	 * @var boolean the value to be set as fourth parameter to {@link CActiveForm::error}.
+	 * @see http://www.yiiframework.com/doc/api/1.1/CActiveForm#error-detail
+	 */
+	public $enableAjaxValidation = true;
+	/**
+	 * This property allows you to disable client valiadtion for certain fields within a form.
+	 * @var boolean the value to be set as fifth parameter to {@link CActiveForm::error}.
+	 * @see http://www.yiiframework.com/doc/api/1.1/CActiveForm#error-detail
+	 */
+	public $enableClientValidation = true;
 
 	/**
 	 * Initializes the widget.
@@ -149,7 +161,7 @@ abstract class TbInput extends CInputWidget
 			$this->label = $this->htmlOptions['label'];
 			unset($this->htmlOptions['label']);
 		}
-		
+
 		if (isset($this->htmlOptions['labelOptions']))
 		{
 			$this->labelOptions = $this->htmlOptions['labelOptions'];
@@ -178,6 +190,10 @@ abstract class TbInput extends CInputWidget
 		if (isset($this->htmlOptions['errorOptions']))
 		{
 			$this->errorOptions = $this->htmlOptions['errorOptions'];
+			if (isset($this->htmlOptions['errorOptions']['enableAjaxValidation']))
+				$this->enableAjaxValidation = (boolean)$this->htmlOptions['errorOptions']['enableAjaxValidation'];
+			if (isset($this->htmlOptions['errorOptions']['enableClientValidation']))
+				$this->enableClientValidation = (boolean)$this->htmlOptions['errorOptions']['enableClientValidation'];
 			unset($this->htmlOptions['errorOptions']);
 		}
 
@@ -384,7 +400,7 @@ abstract class TbInput extends CInputWidget
 	 */
 	protected function getError()
 	{
-		return $this->form->error($this->model, $this->attribute, $this->errorOptions);
+		return $this->form->error($this->model, $this->attribute, $this->errorOptions, $this->enableAjaxValidation, $this->enableClientValidation);
 	}
 
 	/**


### PR DESCRIPTION
Added support for disabling AJAX or client validation for specific form elements.
This is achieved in the following manner: 

``` php
$form->textFieldRow(
    $model, 
    'email', 
    array(
        'errorOptions'=>array(
            'enableAjaxValidation' => false, 
            'enableClientValidation' => false
        )
    )
);.
```

Please note that using this parameters makes sense only if a corresponding validation type is enabled for entire form.
