### PR TITLE
Fix syntax error in widgets/TbDateRangePicker.php

### DIFF
--- a/widgets/TbDateRangePicker.php
+++ b/widgets/TbDateRangePicker.php
@@ -97,7 +97,7 @@ class TbDateRangePicker extends CInputWidget
 	private function setMonthNames()
 	{
 		if (empty($this->options['locale']['monthNames']))
-			$this->options['locale']['monthNames'] = array_values(Yii::app()->locale->getMonthNames('wide', true))
+			$this->options['locale']['monthNames'] = array_values(Yii::app()->locale->getMonthNames('wide', true));
 	}
 
 	/**


### PR DESCRIPTION
Fix syntax error (missing semicolon).
