### PR TITLE
Fix for bootstrap.timepicker.js not releasing input focus in webkit browsers

### DIFF
--- a/assets/css/bootstrap-timepicker.css
+++ b/assets/css/bootstrap-timepicker.css
@@ -118,3 +118,7 @@
 		width: 100%;
 	}
 }
+/* Fix for user focus issue on webkit browsers */
+.no-user-select {
+    -webkit-user-select: none;
+}

--- a/widgets/TbTimePicker.php
+++ b/widgets/TbTimePicker.php
@@ -55,6 +55,11 @@ class TbTimePicker extends CInputWidget
 	{
 		list($name, $id) = $this->resolveNameID();
 
+		// Add a class of no-user-select to widget
+		$this->htmlOptions['class'] = empty($this->htmlOptions['class']) 
+									? 'no-user-select' 
+									: 'no-user-select ' . $this->htmlOptions['class'];
+
 		if ($this->hasModel())
 		{
 			if($this->form)


### PR DESCRIPTION
### Issue # 364

This fixes issue #364, bootstrap.timepicker.js not releasing input focus in webkit browsers.
- Added .no-user-select class with property `-webkit-user-select: none;` to CSS and TimePicker input field
