### PR TITLE
Fix: maintain $grid.find('.keys').attr('title') value on AJAX update.

### DIFF
--- a/assets/js/jquery.json.yiigridview.js
+++ b/assets/js/jquery.json.yiigridview.js
@@ -268,6 +268,11 @@
                             $( '.' + settings.pagerClass, $grid ).hide();
                         }
 
+                        var url_params = $.deparam.querystring(data.url);
+                        delete url_params[settings.ajaxVar];
+                        $grid.find('.keys').attr('title', $.param.querystring(data.url.substr(0, data.url.indexOf('?')), url_params));
+
+                        data.pager.length ? $grid.find('.'+settings.pagerClass+' ul').jqotesub(settings.pagerTemplate, data.pager).show() : $grid.find('.' + settings.pagerClass).hide();
 
                         $.each(data.headers, function(){
                             var $header = $('#' + this.id );

--- a/widgets/TbJsonGridView.php
+++ b/widgets/TbJsonGridView.php
@@ -245,6 +245,7 @@ class TbJsonGridView extends TbGridView
 			$tbody['rows'][0]['class'] = " ";
 		}
 		$tbody['pager'] = $this->renderPager();
+		$tbody['url'] = Yii::app()->getRequest()->getUrl();
 
 		return $tbody;
 	}


### PR DESCRIPTION
Without updating this attribute right, $grid.yiiJsonGridView('getUrl') returns wrong page address, which causes wrong behavior during row deletion.
