### PR TITLE
Bootstrap::getAssetsUrl() conflict with CAsssetManager::$linkAssets

### DIFF
--- a/components/Bootstrap.php
+++ b/components/Bootstrap.php
@@ -455,7 +455,7 @@ class Bootstrap extends CApplicationComponent
 		else
 		{
 			$assetsPath = Yii::getPathOfAlias('bootstrap.assets');
-			$assetsUrl = Yii::app()->assetManager->publish($assetsPath, false, -1, YII_DEBUG);
+			$assetsUrl = Yii::app()->assetManager->publish($assetsPath, false, -1, YII_DEBUG && !Yii::app()->assetManager->linkAssets);
 			return $this->_assetsUrl = $assetsUrl;
 		}
 	}


### PR DESCRIPTION
When constant YII_DEBUG and  CAsssetManager::$linkAssets are both setted as ture, then will cause the following error.

The "forceCopy" and "linkAssets" cannot be both true.
