### PR TITLE
Added the possibility to render append/prepend without a span wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Thank you all
 Antonio Ramirez.
 
 ### YiiBooster version 1.0.7
+- **(enh)** Added the possibility to render append/prepend without a span wrap #414 (Frostmaind)
 - **(enh)** Update x-editable-yii from 1.3.0 to 1.4.0 #413 (magefad)
 
 

--- a/src/widgets/input/TbInput.php
+++ b/src/widgets/input/TbInput.php
@@ -401,7 +401,10 @@ abstract class TbInput extends CInputWidget
 			ob_start();
 			echo '<div class="' . $this->getAddonCssClass() . '">';
 			if (isset($this->prependText))
-				echo CHtml::tag('span', $htmlOptions, $this->prependText);
+				if (isset($htmlOptions['isRaw']) && $htmlOptions['isRaw'])
+					echo $this->prependText;
+				else
+					echo CHtml::tag('span', $htmlOptions, $this->prependText);
 
 			return ob_get_clean();
 		} else
@@ -428,7 +431,10 @@ abstract class TbInput extends CInputWidget
 
 			ob_start();
 			if (isset($this->appendText))
-				echo CHtml::tag('span', $htmlOptions, $this->appendText);
+				if (isset($htmlOptions['isRaw']) && $htmlOptions['isRaw'])
+					echo $this->appendText;
+				else
+					echo CHtml::tag('span', $htmlOptions, $this->appendText);
 
 			echo '</div>';
 			return ob_get_clean();


### PR DESCRIPTION
Can be used like this:

<h4>Example 1</h4>

``` php
echo $form->textFieldRow($model, 'url', array(
    'appendOptions' => array('isRaw' => true), 
    'append' => $this->widget('bootstrap.widgets.TbButton', array('label' => 'Make url'), true),
));
```

<h4>Example 2</h4>

``` php
echo $form->textFieldRow($model, 'url', array(
    'appendOptions' => array('isRaw' => true), 
    'append' => $this->renderPartial('parts/_btn_makeurl',null,true)
));
```

contents of _btn_makeurl.php

``` php

<?php $this->widget('bootstrap.widgets.TbButton', array('label' => 'Make url')); ?>
```

![booster-add2](https://f.cloud.github.com/assets/3715881/326334/b6be92a4-9b2e-11e2-8cb0-b95572c09e27.png)

More examples from twitter bootsrap
![booster-add](https://f.cloud.github.com/assets/3715881/326332/8870b940-9b2e-11e2-8c76-4fc0541885ce.png)
