### PR TITLE
htmlOptions don't put into formView

### DIFF
--- a/widgets/TbFileUpload.php
+++ b/widgets/TbFileUpload.php
@@ -123,7 +123,7 @@ class TbFileUpload extends CJuiInputWidget
 
 		$this->render($this->uploadView);
 		$this->render($this->downloadView);
-			$this->render($this->formView, array('name'=>$name, 'htmlOptions'=>$this->htmlOptions));
+			$this->render($this->formView, array('name'=>$name, 'htmlOptions'=>$htmlOptions));
 
 		if ($this->previewImages || $this->imageProcessing)
 			$this->render($this->previewImagesView);


### PR DESCRIPTION
in form view you used $this->htmlOptions and $htmlOptions,
but if you put

``` php
$this->render($this->formView, array('name'=>$name, 'htmlOptions'=>$this->htmlOptions));
```

how about multiple ?
