### PR TITLE
Selectable rows compatibility with bulkActions

### DIFF
--- a/src/components/Bootstrap.php
+++ b/src/components/Bootstrap.php
@@ -299,6 +299,7 @@ class Bootstrap extends CApplicationComponent
      */
     public function registerPopover($selector = null, $options = array())
     {
+        $this->registerTooltip(); // Popover requires the tooltip plugin
         if (!isset($options['selector'])) {
             $options['selector'] = '[rel=popover]';
         }


### PR DESCRIPTION
Enh #490

I have a grid where I enable selectableRows. This doesn't work when the current implementation of TbBulkActions, as the bulk actions button are disabled until a click event on any of the checkboxes in the grid. However, when selectableRows is enabled, user is not required to check the checkbox, but any click in the row will check respective checkbox.
