### PR TITLE
Remove BOM from breadcrumb widget

### DIFF
--- a/widgets/TbBreadcrumbs.php
+++ b/widgets/TbBreadcrumbs.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /*##  TbCrumb class file.
  *
  * @author Christoffer Niska <ChristofferNiska@gmail.com>


### PR DESCRIPTION
There was a byte order mark (BOM) at the beginning of the breadcrumb widget causing the first breadcrumb on a page to be rendered some pixels below the expected position. 

You won't see the change in the diff on GitHub but you will see it in the hex editor of your choice.

Here is a good [article](http://www.w3.org/International/questions/qa-byte-order-mark.en.php) about this issue, containing an [example](http://www.w3.org/International/questions/examples/phpbomtest.php) to reproduce this issue in your browser.
