### PR TITLE
Keys tag always must be rendered

### DIFF
--- a/src/widgets/TbExtendedGridView.php
+++ b/src/widgets/TbExtendedGridView.php
@@ -246,10 +246,7 @@ class TbExtendedGridView extends TbGridView
 	public function renderKeys()
 	{
 		$data = $this->dataProvider->getData();
-		if (empty($data)) {
-			return false;
-		}
-
+		
 		if (!$this->sortableRows || !$this->getAttribute($data[0], (string)$this->sortableAttribute)) {
 			parent::renderKeys();
 		}


### PR DESCRIPTION
if we use grid filters and we don't have result then the next attempt to filter throws error (the gridview.getUrl() returns undefined)
