### PR TITLE
fix for ['HTTP_USER_AGENT'] not being set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Antonio Ramirez.
 - **(fix)** Now the bootstrap CSS files are being included according to the combination of `enableCdn`, `minifyCss`, `responsiveCss` and `fontAwesomeCss` parameters. #528 #510 (hijarian)
 - **(enh)** Added two parameters to Bootstrap component, `ajaxCssLoad` and `ajaxJsLoad`, to control loading CSS and JS assets in AJAX calls #514 (ianare)
 - **(fix)** TbBox action buttons now display correcftly with icons (fleuryc)
+- **(fix)** Check that $_SERVER['HTTP_USER_AGENT'] is set when loading MSIE font awesome (ianare)
 
 ## YiiBooster version 1.0.7
 - **(fix)** HighCharts now accept data with zero values normally #345 (dheering)

--- a/src/components/Bootstrap.php
+++ b/src/components/Bootstrap.php
@@ -494,7 +494,7 @@ class Bootstrap extends CApplicationComponent
 	 */
 	public function registerFontAwesomeCss()
 	{
-		if (strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE 7.0')) {
+		if (isset($_SERVER['HTTP_USER_AGENT']) && strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE 7.0')) {
 			$this->registerPackage('font-awesome')->registerPackage('font-awesome-ie7');
 		} else {
 			$this->registerPackage('font-awesome');


### PR DESCRIPTION
In some cases the server variable 'HTTP_USER_AGENT' is not sent by the client. This was causing some warnings on our production servers.
