### PR TITLE
Fixed bug that causes no alerts to be displayed by default

### DIFF
--- a/src/widgets/TbAlert.php
+++ b/src/widgets/TbAlert.php
@@ -110,7 +110,7 @@ class TbAlert extends CWidget
 		}
 
 		// Display all alert types by default.
-		if (!isset($this->alerts)) {
+		if (empty($this->alerts)) {
 			$this->alerts = array(
 				self::TYPE_SUCCESS,
 				self::TYPE_INFO,


### PR DESCRIPTION
`$alerts` is always set to an empty array in the class definition.
