### PR TITLE
Check property $alerts on empty

### DIFF
--- a/src/widgets/TbAlert.php
+++ b/src/widgets/TbAlert.php
@@ -110,7 +110,7 @@ class TbAlert extends CWidget
 		}
 
 		// Display all alert types by default.
-		if (!isset($this->alerts)) {
+		if (!isset($this->alerts) || empty($this->alerts)) {
 			$this->alerts = array(
 				self::TYPE_SUCCESS,
 				self::TYPE_INFO,


### PR DESCRIPTION
We should check property on empty because property is exist
