### PR TITLE
Update TbRelationalColumn.php

### DIFF
--- a/src/widgets/TbRelationalColumn.php
+++ b/src/widgets/TbRelationalColumn.php
@@ -115,7 +115,7 @@ class TbRelationalColumn extends TbDataColumn
 		if ($this->grid->dataProvider instanceof CActiveDataProvider) {
 			$key = $this->grid->dataProvider->keyAttribute === null ? $data->getPrimaryKey()
 				: $data->{$this->keyAttribute};
-			return is_array($key) ? implode(',', $key) : $key;
+			return is_array($key) ? implode('--', $key) : $key;
 		}
 		if ($this->grid->dataProvider instanceof CArrayDataProvider || $this->grid->dataProvider instanceof CSqlDataProvider) {
 			return is_object($data) ? $data->{$this->grid->dataProvider->keyField}


### PR DESCRIPTION
We should not use ',' to seprate multiple primary keys, because in that case $('#relatedinfo' + rowid) will always return []
