### PR TITLE
Introduce widgetOptions attribute to Select2 widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Antonio Ramirez.
 
 
 ## YiiBooster version 1.1.0
+- **(enh)** Introduce widgetOptions attribute for Select2 widget (soee)
 - **(enh)** Added Italian translation for `TbHtml5Editor` #544 (realtebo)
 - **(enh)** Rearranged build script to accommodate Composer installed libraries better. (hijarian)
 - **(enh)** Added composer file #566 (gureedo)

--- a/src/widgets/TbActiveForm.php
+++ b/src/widgets/TbActiveForm.php
@@ -489,21 +489,20 @@ class TbActiveForm extends CActiveForm
 	}
 
 	/**
-	 *### .select2Row()
-	 *
-	 * TODO: WTF is a input of type `Select2`? Rename it to something more meaningful!
-	 *
 	 * Renders a select2 field row
+	 *
+	 * @todo WTF is a input of type `Select2`? Rename it to something more meaningful!
 	 *
 	 * @param CModel $model
 	 * @param string $attribute
+	 * @param array $widgetOptions
 	 * @param array $htmlOptions
 	 *
 	 * @return string
 	 */
-	public function select2Row($model, $attribute, $htmlOptions = array())
+	public function select2Row($model, $attribute, $widgetOptions = array(), $htmlOptions = array())
 	{
-		return $this->inputRow(TbInput::TYPE_SELECT2, $model, $attribute, null, $htmlOptions);
+		return $this->inputRow(TbInput::TYPE_SELECT2, $model, $attribute, $widgetOptions, $htmlOptions);
 	}
 
 	/**

--- a/src/widgets/TbSelect2.php
+++ b/src/widgets/TbSelect2.php
@@ -22,30 +22,11 @@ class TbSelect2 extends CInputWidget
 	 * @see TbActionForm->inputRow
 	 */
 	public $form;
-	/**
-	 * @var array @param data for generating the list options (value=>display)
-	 */
-	public $data = array();
 
 	/**
-	 * @var string[] the JavaScript event handlers.
+	 * @var array widget options
 	 */
-	public $events = array();
-
-	/**
-	 * @var bool whether to display a dropdown select box or use it for tagging
-	 */
-	public $asDropDownList = true;
-
-	/**
-	 * @var string the default value.
-	 */
-	public $val;
-
-	/**
-	 * @var
-	 */
-	public $options;
+	public $widgetOptions= array();
 
 	/**
 	 *### .init()
@@ -54,7 +35,12 @@ class TbSelect2 extends CInputWidget
 	 */
 	public function init()
 	{
-		if (empty($this->data) && $this->asDropDownList === true) {
+		$this->widgetOptions['asDropDownList']= isset($this->widgetOptions['asDropDownList']) ? $this->widgetOptions['asDropDownList'] : true;		
+		$this->widgetOptions['data']= isset($this->widgetOptions['data']) ? $this->widgetOptions['data'] : array();
+		$this->widgetOptions['options']= isset($this->widgetOptions['options']) ? $this->widgetOptions['options'] : array();				
+		$this->widgetOptions['events']= isset($this->widgetOptions['events']) ? $this->widgetOptions['events'] : array();
+
+		if (empty($this->widgetOptions['data']) && $this->widgetOptions['asDropDownList'] === true) {
 			throw new CException(Yii::t('zii', '"data" attribute cannot be blank'));
 		}
 
@@ -72,23 +58,23 @@ class TbSelect2 extends CInputWidget
 
 		if ($this->hasModel()) {
 			if ($this->form) {
-				echo $this->asDropDownList
+				echo $this->widgetOptions['asDropDownList']
 					?
-					$this->form->dropDownList($this->model, $this->attribute, $this->data, $this->htmlOptions)
+					$this->form->dropDownList($this->model, $this->attribute, $this->widgetOptions['data'], $this->htmlOptions)
 					:
 					$this->form->hiddenField($this->model, $this->attribute, $this->htmlOptions);
 			} else {
-				echo $this->asDropDownList
+				echo $this->widgetOptions['asDropDownList']
 					?
-					CHtml::activeDropDownList($this->model, $this->attribute, $this->data, $this->htmlOptions)
+					CHtml::activeDropDownList($this->model, $this->attribute, $this->widgetOptions['data'], $this->htmlOptions)
 					:
 					CHtml::activeHiddenField($this->model, $this->attribute, $this->htmlOptions);
 			}
 
 		} else {
-			echo $this->asDropDownList
+			echo $this->widgetOptions['asDropDownList']
 				?
-				CHtml::dropDownList($name, $this->value, $this->data, $this->htmlOptions)
+				CHtml::dropDownList($name, $this->value, $this->widgetOptions['data'], $this->htmlOptions)
 				:
 				CHtml::hiddenField($name, $this->value, $this->htmlOptions);
 		}
@@ -107,13 +93,13 @@ class TbSelect2 extends CInputWidget
 		Yii::app()->bootstrap->registerAssetCss('select2.css');
 		Yii::app()->bootstrap->registerAssetJs('select2.js');
 
-		$options = !empty($this->options) ? CJavaScript::encode($this->options) : '';
+		$options = !empty($this->widgetOptions['options']) ? CJavaScript::encode($this->widgetOptions['options']) : '';
 
-		$defValue = !empty($this->val) ? ".select2('val', '$this->val')" : '';
+		$defValue = !empty($this->widgetOptions['val']) ? ".select2('val', '$this->widgetOptions['val']')" : '';
 
 		ob_start();
 		echo "jQuery('#{$id}').select2({$options})$defValue";
-		foreach ($this->events as $event => $handler) {
+		foreach ($this->widgetOptions['events'] as $event => $handler) {
 			echo ".on('{$event}', " . CJavaScript::encode($handler) . ")";
 		}
 
@@ -122,12 +108,12 @@ class TbSelect2 extends CInputWidget
 
 	private function setDefaultWidthIfEmpty()
 	{
-		if (empty($this->options)) {
+		if (!is_array($this->widgetOptions['options'])) {
 			$this->options = array();
 		}
 
-		if (empty($this->options['width'])) {
-			$this->options['width'] = 'resolve';
+		if (empty($this->widgetOptions['options']['width'])) {
+			$this->widgetOptions['options']['width'] = 'resolve';
 		}
 	}
 }

--- a/src/widgets/input/TbInputHorizontal.php
+++ b/src/widgets/input/TbInputHorizontal.php
@@ -596,26 +596,6 @@ class TbInputHorizontal extends TbInput
 	 */
 	protected function select2Field()
 	{
-		if (isset($this->htmlOptions['options'])) {
-			$options = $this->htmlOptions['options'];
-			unset($this->htmlOptions['options']);
-		}
-
-		if (isset($this->htmlOptions['events'])) {
-			$events = $this->htmlOptions['events'];
-			unset($this->htmlOptions['events']);
-		}
-
-		if (isset($this->htmlOptions['data'])) {
-			$data = $this->htmlOptions['data'];
-			unset($this->htmlOptions['data']);
-		}
-
-		if (isset($this->htmlOptions['asDropDownList'])) {
-			$asDropDownList = $this->htmlOptions['asDropDownList'];
-			unset($this->htmlOptions['asDropDownList']);
-		}
-
 		echo $this->getLabel();
 		echo '<div class="controls">';
 		echo $this->getPrepend();
@@ -624,10 +604,7 @@ class TbInputHorizontal extends TbInput
 			array(
 				'model' => $this->model,
 				'attribute' => $this->attribute,
-				'options' => isset($options) ? $options : array(),
-				'events' => isset($events) ? $events : array(),
-				'data' => isset($data) ? $data : array(),
-				'asDropDownList' => isset($asDropDownList) ? $asDropDownList : true,
+				'widgetOptions' => $this->data,				
 				'htmlOptions' => $this->htmlOptions,
 				'form' => $this->form
 			)

--- a/src/widgets/input/TbInputVertical.php
+++ b/src/widgets/input/TbInputVertical.php
@@ -522,32 +522,6 @@ class TbInputVertical extends TbInput
 	 */
 	protected function select2Field()
 	{
-		if (isset($this->htmlOptions['options'])) {
-			$options = $this->htmlOptions['options'];
-			unset($this->htmlOptions['options']);
-		}
-
-		if (isset($this->htmlOptions['events'])) {
-			$events = $this->htmlOptions['events'];
-			unset($this->htmlOptions['events']);
-		}
-
-		if (isset($this->htmlOptions['data'])) {
-			$data = $this->htmlOptions['data'];
-			unset($this->htmlOptions['data']);
-		}
-
-		if (isset($this->htmlOptions['asDropDownList'])) {
-			$asDropDownList = $this->htmlOptions['asDropDownList'];
-			unset($this->htmlOptions['asDropDownList']);
-		}
-		
-		if (isset($this->htmlOptions['val']))
-		{
-			$val = $this->htmlOptions['val'];
-			unset($this->htmlOptions['val']);
-		}
-
 		echo $this->getLabel();
 		echo $this->getPrepend();
 		$this->widget(
@@ -555,11 +529,7 @@ class TbInputVertical extends TbInput
 			array(
 				'model' => $this->model,
 				'attribute' => $this->attribute,
-				'options' => isset($options) ? $options : array(),
-				'events' => isset($events) ? $events : array(),
-				'data' => isset($data) ? $data : array(),
-				'asDropDownList' => isset($asDropDownList) ? $asDropDownList : true,
-				'val' => isset($val) ? $val : null,
+				'widgetOptions' => $this->data,
 				'htmlOptions' => $this->htmlOptions,
 				'form' => $this->form
 			)


### PR DESCRIPTION
htmlOptions['options'] item was used to store Select2 plugin configuration and it was impossible to use it as native htemlOptions element. Introduced widgetOptions arguments now shuld store all plugin related configuration so it wont't interfere native htmlOption attribute.
