### PR TITLE
Fix datetimepicker assets loading: fix TbDateTimePicker to load locate f...

### DIFF
--- a/src/widgets/TbDateTimePicker.php
+++ b/src/widgets/TbDateTimePicker.php
@@ -96,13 +96,13 @@ class TbDateTimePicker extends CInputWidget
 	public function registerLanguageScript()
 	{
 		if (isset($this->options['language']) && $this->options['language'] != 'en') {
-			$file = 'locales/bootstrap-datepicker.' . $this->options['language'] . '.js';
+			$file = 'locales/bootstrap-datetimepicker.' . $this->options['language'] . '.js';
 			if (@file_exists(Yii::getPathOfAlias('bootstrap.assets.bootstrap-datetimepicker') . '/js/' . $file)) {
 				if (Yii::app()->bootstrap->enableCdn) {
 					// Not in CDN yet
-					Yii::app()->bootstrap->registerAssetJs('locales/bootstrap-datetimepicker.' . $this->options['language'] . '.js');
+					Yii::app()->bootstrap->registerAssetJs('../bootstrap-datetimepicker' . '/js/' . $file);
 				} else {
-					Yii::app()->bootstrap->registerAssetJs('locales/bootstrap-datetimepicker.' . $this->options['language'] . '.js');
+					Yii::app()->bootstrap->registerAssetJs('../bootstrap-datetimepicker' . '/js/' . $file);
 				}
 			}
 		}

--- a/src/widgets/TbEditableField.php
+++ b/src/widgets/TbEditableField.php
@@ -568,6 +568,17 @@ class TbEditableField extends CWidget
 			);
 			$widget->registerLanguageScript();
 		}
+		elseif ($this->type == 'datetime') {
+			$this->packageRegistry->registerPackage('datetimepicker');
+			
+			/** @var $widget TbDateTimePicker */
+			$widget = Yii::app()->widgetFactory->createWidget(
+				$this->getOwner(),
+				'bootstrap.widgets.TbDateTimePicker',
+				array('options' => $this->options['datetimepicker'])
+			);
+			$widget->registerLanguageScript();
+		}
 		//include moment.js if needed
 		if ($this->type == 'combodate') {
 			$this->packageRegistry->registerPackage('moment');


### PR DESCRIPTION
Fixes for two bugs:
1. TbDateTimePicker would never register locate JS, for it was looking for them in wrong directory
2. TbEditableField did not load necessary scripts for 'datetime' field type ('date' field type does not require additional script loading, as its scripts are in 'bootstrap-editable.js', but scripts for 'datetime' field are in a separate package dir 'bootstrap-datetimepicker/js')
