### PR TITLE
Fix work with zero values in TbExtendedGridView sortable

### DIFF
--- a/src/widgets/TbExtendedGridView.php
+++ b/src/widgets/TbExtendedGridView.php
@@ -250,7 +250,7 @@ class TbExtendedGridView extends TbGridView
 	{
 		$data = $this->dataProvider->getData();
 		
-		if (!$this->sortableRows || (isset($data[0]) && !$this->getAttribute($data[0], (string)$this->sortableAttribute))) {
+		if (!$this->sortableRows || (isset($data[0]) && !isset($data[0]->attributes[(string)$this->sortableAttribute]))) {
 			parent::renderKeys();
 		}
 


### PR DESCRIPTION
If феекшигеу is present and its value is zero, old check will make false positive result.
