### PR TITLE
case empty message

### DIFF
--- a/src/widgets/TbAlert.php
+++ b/src/widgets/TbAlert.php
@@ -234,7 +234,7 @@ class TbAlert extends CWidget
 			echo '<a href="#" class="close" data-dismiss="alert">' . $alert['closeText'] . '</a>';
 		}
 
-		echo $alertText;
+		echo empty($alertText) ? 'Empty <strong>'.$type.'</strong> alert!' : $alertText;
 		echo CHtml::closeTag('div');
 	}
 }


### PR DESCRIPTION
I have faced this case with my project @ CleverTech, I think it is not correct to display an empty alert box, we should display a default message or do not show the box at all ... I choose to display a default message to not loose the info that there was an error
