### PR TITLE
Fix for TbSelect2

### DIFF
--- a/src/widgets/TbSelect2.php
+++ b/src/widgets/TbSelect2.php
@@ -150,10 +150,11 @@ class TbSelect2 extends CInputWidget
         }
 
 		ob_start();
-		echo "jQuery('#{$id}').select2({$options})$defValue";
+		echo "jQuery('#{$id}').select2({$options})";
 		foreach ($this->events as $event => $handler) {
 			echo ".on('{$event}', " . CJavaScript::encode($handler) . ")";
 		}
+		echo $defValue;
 
 		Yii::app()->getClientScript()->registerScript(__CLASS__ . '#' . $this->getId(), ob_get_clean() . ';');
 	}


### PR DESCRIPTION
In version 3.4.1 of select2 method "enable" returns "true".
When using "disabled" property and events this widget generate js code like this "jQuery('#selector').select2({options}).select2('enable', false).on('change', ...)"
which throw js error because of .select2('enable', false) returns boolean instead of object.
BUT! This fix only allow to set one of two property in one time.
