### PR TITLE
Possible bug in TbInput::getContainerCssClass()

### DIFF
--- a/src/widgets/input/TbInput.php
+++ b/src/widgets/input/TbInput.php
@@ -522,8 +522,7 @@ abstract class TbInput extends CInputWidget
 	 */
 	protected function getContainerCssClass()
 	{
-		$attribute = $this->attribute;
-		return $this->model->hasErrors(CHtml::resolveName($this->model, $attribute)) ? CHtml::$errorCss : '';
+		return $this->model->hasErrors($this->attribute) ? CHtml::$errorCss : '';
 	}
 
 	/**


### PR DESCRIPTION
Seems like a bug to me. Attribute name should be passed to CModel::hasErros(), not the html resolved name
http://www.yiiframework.com/doc/api/1.1/CModel#hasErrors-detail
