### PR TITLE
TbEditableColumn options missing

### DIFF
--- a/src/widgets/TbEditableColumn.php
+++ b/src/widgets/TbEditableColumn.php
@@ -77,6 +77,7 @@ class TbEditableColumn extends TbDataColumn
 		$widget = $this->grid->controller->createWidget('TbEditableField', $options);
 		
 		
+		$widget->buildJsOptions();
 		$widget->registerAssets();
 		
 		if (!$this->_isScriptRendered) {


### PR DESCRIPTION
May be I don't understand how to use it in a right way, but after I checked out 3.0.0 version my TbEditableColumn widgets failed to perform any actions. I found out that $options where empty in TbEditableColumn::getClientScript().

Hope this request makes some sense.
