### PR TITLE
bulkActions checkbox not saving anymore

### DIFF
--- a/src/assets/js/jquery.saveselection.gridview.js
+++ b/src/assets/js/jquery.saveselection.gridview.js
@@ -1,9 +1,3 @@
-/* =========================================================
- * rewritten by Amr Bedair <amr.bedair@gmail.com>
- * @since booster v4.0.0-beta-2
- *  
- * ========================================================= */
-
 (function($){
 
   var checkedItems = [];
@@ -13,20 +7,47 @@
    * @param id string the ID of the grid view container
    */
   $.fn.yiiGridView.initBulkActions = function (id) {
-	  
+    
     $(document).on("click change", "#"+id+" input[type=checkbox]", function() {
     	
     	var grid = $('#'+id);
-    	
-    	if ($("#"+id+' tbody input[type=checkbox]:checked').length) {
-    	  
-        $(".bulk-actions-btn", grid).removeClass("disabled");
-        $("div.bulk-actions-blocker", grid).hide();
-      } else {
-    	  
-        $(".bulk-actions-btn", grid).addClass("disabled");
-        $("div.bulk-actions-blocker", grid).show();
-      }
+    	if ($(this).val()) {
+			if ($(this).is(':checked')) {
+				if (this.id==id+'_c0_all'){
+					$("#"+id+' tbody input[type=checkbox]:checked').each(function() {
+							if (checkedItems.indexOf($(this).val())<0) {
+								checkedItems.push($(this).val());
+							}
+						})
+				}else{
+					if (checkedItems.indexOf($(this).val())<0) {
+						checkedItems.push($(this).val());
+					}
+				}
+			} else {
+				if (this.id==id+'_c0_all'){
+					$("#"+id+' tbody input[type=checkbox]').each(function() {
+						if (checkedItems.indexOf($(this).val())>0) {
+								console.log($(this).val())
+								
+								checkedItems.splice( $.inArray($(this).val(), checkedItems), 1 );
+						}	
+						})
+				}else{
+					
+					checkedItems.pop($(this).val());
+				}
+			}
+		}
+		if (checkedItems.length)
+		{
+
+	        $(".bulk-actions-btn", grid).removeClass("disabled");
+	        $("div.bulk-actions-blocker",grid).hide();
+    	} else {
+    		$(".bulk-actions-btn", grid).addClass("disabled");
+    		$("div.bulk-actions-blocker",grid).show();
+    	}
     });
   };
 
@@ -35,18 +56,19 @@
    * @param id string the ID of the grid view container
    */
   $.fn.yiiGridView.afterUpdateGrid = function (id) {
-    
-    if ($("#"+id+' tbody input[type=checkbox]:checked').length) {
+	  
+    if (checkedItems.length>0) {
     	
-      var grid = $('#'+id);
-    	
-      $(".bulk-actions-btn", grid).removeClass("disabled");
-      $("div.bulk-actions-blocker", grid).hide();
-      $.each($("#"+id+' tbody input[type=checkbox]:checked'), function(index, item) {
-        var row = $("input[value="+item+"]", grid);
-        if (!row.is(':checked'))
-          row.attr("checked", "checked");
-      });
+    	var grid = $('#'+id);
+    	 
+    	$(".bulk-actions-btn", grid).removeClass("disabled");
+    	$("div.bulk-actions-blocker",grid).hide();
+    	$.each(checkedItems, function(index, item) {
+        var row = $("input[value="+item.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")+"]", grid);
+        	if (!row.is(':checked')) {
+        		row.attr("checked", "checked");
+        	}
+    	});
     }
   };
 
@@ -54,9 +76,23 @@
    * Returns array of checked items ids
    * @returns {Array}
    */
-  $.fn.yiiGridView.getCheckedRowsIds = function (id) {
-	return $("#"+id+' tbody input[type=checkbox]:checked').map(function() { return $(this).val(); }).get();
+  $.fn.yiiGridView.getCheckedItems = function (id) {
+	  
+	  //return $("#"+id+' tbody input[type=checkbox]:checked').map(function() { return $(this).val(); }).get();
+	  return checkedItems;
   }
+	
+	/**
+   * Returns array of checked items ids
+   * @returns {Array}
+   */
+  $.fn.yiiGridView.getPageCheckedItems = function (id) {
+	  
+	  return $("#"+id+' tbody input[type=checkbox]:checked').map(function() { return $(this).val(); }).get();
+	  
+  }
+
+  
 
 
 })(jQuery);


### PR DESCRIPTION
Since i've updated yiibooster to v.3.1.1 checked boxes does not save anymore while changing page. 
In the $.fn.yiiGridView.initBulkActions function there is no more a "push" inside checkedItems array, so the script isn't saving anything. After changing gridvirew page, all the checked elements are gone, so if i go back to the last gridview page no checkbox is checked.
So, now the select all checkbox is working but checkboxes save between gridview page isn't.
Also illegar javascript character used in value of column is still not checked (maybe there is a better way but at least this is working.
The pop function in checkedItems is wrong, because it causes the deletion of all element after the one unchecked, it's better use slice().
