### PR TITLE
Removed short array syntax (PHP 5.4+) #877

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ Antonio Ramirez.
 
 ## YiiBooster latest development alpha
 -
-  
+
 ## YiiBooster version 4.1.0
-- **(enh)** update TbHtml to the latest 1.3.0, and addeing its dependency TbArray  
-- **(fix)** TbActiveForm fix "[a]attr" format attribute #856 
-- **(fix)** allow multi relational column - #872  
-- **(enh)** 
+- **(fix)** Removed short array syntax (PHP 5.4+) #877 (BigDan256)
+- **(enh)** update TbHtml to the latest 1.3.0, and addeing its dependency TbArray
+- **(fix)** TbActiveForm fix "[a]attr" format attribute #856
+- **(fix)** allow multi relational column - #872
+- **(enh)**
 
 ## YiiBooster version 4.0.1
 - **(fix)** fix gii generated TbActiveForm code - #851
@@ -33,11 +34,11 @@ Antonio Ramirez.
 - Finalize buttons, and button groups
 - Finalize typeahead
 - more work done on grids, extended grids, bulk actions
-- upgrade font awesome 
+- upgrade font awesome
 
 ## YiiBooster version 4.0.0-beta-1
 - TbActiveForm working
-- more widgets working 
+- more widgets working
 - api doc
 - travis, and scrutinizer ci
 
@@ -45,34 +46,34 @@ Antonio Ramirez.
 - upgrade the bootstrap version to 3.1.1
 - upgrade and fix many widgets to work with bootstrap 3.1.1
 - many widgets still not ported
-- code structure is not final yet 
+- code structure is not final yet
 - working widgets (TbAlert, TbBadge, TbButton, TbJumbotron, TbLabel, TbProgressBar, TbEditableField, TbEditableColumn, TbEditableDetailView, TbHighChart, TbActiveForm, TbPager)
 - not all TbActiveForm controls are ported yet
 
 ## YiiBooster version 3.0.0
 - **(fix)** TbExtendedGridView - TbProgress inside cell css fix - #448
-- **(enh)** TbGridView - try to register TbEditableColumn scripts for empty providers - works only with CActiveDataProvider - #526 
+- **(enh)** TbGridView - try to register TbEditableColumn scripts for empty providers - works only with CActiveDataProvider - #526
 - **(fix)** TbDatePicker - noconflicts fix - #531
-- **(fix)** TbBox header css fix to overflow its contents - #559 
+- **(fix)** TbBox header css fix to overflow its contents - #559
 - **(fix)** TbEditableSaver moved to comonents instead of widgets
-- **(fix)** TbButtonColumn not displaying images - #604 
-- **(enh)** TbExtendedGridView - with chart categories bindings on xAxis - #608  
-- **(enh)** TbActiveForm - custom label support for radioButtonRow and checkBoxRow - #776  
+- **(fix)** TbButtonColumn not displaying images - #604
+- **(enh)** TbExtendedGridView - with chart categories bindings on xAxis - #608
+- **(enh)** TbActiveForm - custom label support for radioButtonRow and checkBoxRow - #776
 - **(enh)** TbToggleAction - now supports composite key - #668
 - **(enh)** TbExtendedGrid - supporting 'sortableRows' with composite key models - #669
 - **(enh)** TbTimePicker - update to the latest bootstrap-timepicker - #700
-- **(fix)** TbActiveForm - Prevent placeholder rendering as list item - #774 	
+- **(fix)** TbActiveForm - Prevent placeholder rendering as list item - #774
 - **(fix)** TbInput - fix bug using CHtml::resolveName() in getContainerCssClass() - #775
-- **(fix)** TbFormInputElement - fix passing attributes to widget - #773 
-- **(fix)** TbTimePicker error on client side validation - #716 
+- **(fix)** TbFormInputElement - fix passing attributes to widget - #773
+- **(fix)** TbTimePicker error on client side validation - #716
 - **(fix)** Fixed keyField for CArrayDataProvider in TbExtendedGridView - #738
 - **(fix)** TbRelationalColumn - adding submitData - #741
-- **(fix)** packages fix x-editable depends on bootstrap - #742 
-- **(enh)** TbEditableColumn now supports CArrayDataProvider as well as CActiveDataProvider - #745 
+- **(fix)** packages fix x-editable depends on bootstrap - #742
+- **(enh)** TbEditableColumn now supports CArrayDataProvider as well as CActiveDataProvider - #745
 - **(fix)** TbHtml FontAwesome is now working well- #746
-- **(enh)** TbEditable - adding support for the 'source' to be a function that takes the $model as an attribute and returns the proper array 
-- **(fix)** TbSelect2 - disabled fix - #752 
-- **(fix)** JSON Grid now sorts in both ways - #753 
+- **(enh)** TbEditable - adding support for the 'source' to be a function that takes the $model as an attribute and returns the proper array
+- **(fix)** TbSelect2 - disabled fix - #752
+- **(fix)** JSON Grid now sorts in both ways - #753
 - **(fix)** TbGroupGridView - fix rows id - #755
 - **(fix)** TbFileUpload - allow multi instance in the same page - #756
 - **(enh)** TbExtendedGridView - Grid/Chart switcher - fix of chart auto reflow

--- a/src/userdoc/highcharts/example.basic.php
+++ b/src/userdoc/highcharts/example.basic.php
@@ -4,9 +4,9 @@ $this->widget(
     array(
         'options' => array(
             'series' => array(
-                [
-                    'data' => [1, 2, 3, 4, 5, 1, 2, 1, 4, 3, 1, 5]
-                ]
+                array(
+                    'data' => array(1, 2, 3, 4, 5, 1, 2, 1, 4, 3, 1, 5)
+                )
             )
         )
     )

--- a/src/userdoc/highcharts/example.function_in_options.php
+++ b/src/userdoc/highcharts/example.function_in_options.php
@@ -10,9 +10,9 @@ $this->widget(
                     }"),
             ),
             'series' => array(
-                [
-                    'data' => [1, 2, 3, 4]
-                ]
+                array(
+                    'data' => array(1, 2, 3, 4)
+                )
             )
         )
     )

--- a/src/userdoc/highcharts/example.official_demo.php
+++ b/src/userdoc/highcharts/example.official_demo.php
@@ -12,19 +12,19 @@ $this->widget(
                 'x' -20
             ),
             'xAxis' => array(
-                'categories' => ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+                'categories' => array('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec')
             ),
             'yAxis' => array(
                 'title' => array(
                     'text' =>  'Temperature (°C)',
                 ),
-                'plotLines' => [
-                    [
+                'plotLines' => array(
+                    array(
                         'value' => 0,
                         'width' => 1,
                         'color' => '#808080'
-                    ]
-                ],
+                    )
+                ),
             ),
             'tooltip' => array(
                 'valueSuffix' => '°C'
@@ -36,22 +36,22 @@ $this->widget(
                 'borderWidth' => 0
             ),
             'series' => array(
-                [
+                array(
                     'name' => 'Tokyo',
-                    'data' => [7.0, 6.9, 9.5, 14.5, 18.2, 21.5, 25.2, 26.5, 23.3, 18.3, 13.9, 9.6]
-                ],
-                [
+                    'data' => array(7.0, 6.9, 9.5, 14.5, 18.2, 21.5, 25.2, 26.5, 23.3, 18.3, 13.9, 9.6)
+                ),
+                array(
                     'name' => 'New York',
-                    'data' => [-0.2, 0.8, 5.7, 11.3, 17.0, 22.0, 24.8, 24.1, 20.1, 14.1, 8.6, 2.5]
-                ],
-                [
+                    'data' => array(-0.2, 0.8, 5.7, 11.3, 17.0, 22.0, 24.8, 24.1, 20.1, 14.1, 8.6, 2.5)
+                ),
+                array(
                     'name' => 'Berlin',
-                    'data' => [-0.9, 0.6, 3.5, 8.4, 13.5, 17.0, 18.6, 17.9, 14.3, 9.0, 3.9, 1.0]
-                ],
-                [
+                    'data' => array(-0.9, 0.6, 3.5, 8.4, 13.5, 17.0, 18.6, 17.9, 14.3, 9.0, 3.9, 1.0)
+                ),
+                array(
                     'name' => 'London',
-                    'data' => [3.9, 4.2, 5.7, 8.5, 11.9, 15.2, 17.0, 16.6, 14.2, 10.3, 6.6, 4.8]
-                ]
+                    'data' => array(3.9, 4.2, 5.7, 8.5, 11.9, 15.2, 17.0, 16.6, 14.2, 10.3, 6.6, 4.8)
+                )
             )
         ),
         'htmlOptions' => array(

--- a/src/userdoc/highcharts/example.zeros_in_data.php
+++ b/src/userdoc/highcharts/example.zeros_in_data.php
@@ -4,14 +4,14 @@ $this->widget(
     array(
         'options' => array(
             'series' => array(
-                [
-                    'data' => [0, 1.5, 4, 3, 1, 0, -1, -3, -4, -1.5, 0]
-                ],
-                [
+                array(
+                    'data' => array(0, 1.5, 4, 3, 1, 0, -1, -3, -4, -1.5, 0)
+                ),
+                array(
                     'data' => new CJavaScriptExpression(
                         '[0, -3/2, -2*2, -0.3e1, -Math.pow(354,0), 1-1, 3/3, 3, 4, 4-2.5, 0]'
                     )
-                ]
+                )
             )
         )
     )

--- a/src/userdoc/redactorjs/example.basic.php
+++ b/src/userdoc/redactorjs/example.basic.php
@@ -1,8 +1,8 @@
 <?php // Basic usage of TbRedactorJs widget
 $this->widget(
     'booster.widgets.TbRedactorJs',
-    [
+    array(
         'name' => 'some_name',
         'value' => '<b>Here is the text which will be put into editor view upon opening.</b>',
-    ]
+    )
 );

--- a/src/userdoc/redactorjs/example.callbacks_passing.php
+++ b/src/userdoc/redactorjs/example.callbacks_passing.php
@@ -1,16 +1,16 @@
 <?php // Basic usage of TbRedactorJs widget
 $this->widget(
     'booster.widgets.TbRedactorJs',
-    [
+    array(
         'name' => 'fancy_text',
         'value' => 'Press Enter in here to test the callback.',
-        'editorOptions' => [
+        'editorOptions' => array(
             'enterCallback' => new CJavaScriptExpression(
                 'function (event) {
                     console.debug(event);
                     $.notify("I see you have pressed Enter...", "warning");
                 }'
             )
-        ],
-    ]
+        ),
+    )
 );

--- a/src/userdoc/redactorjs/example.with_lang_and_plugins.php
+++ b/src/userdoc/redactorjs/example.with_lang_and_plugins.php
@@ -1,12 +1,12 @@
 <?php // Basic usage of TbRedactorJs widget
 $this->widget(
     'booster.widgets.TbRedactorJs',
-    [
+    array(
         'name' => 'another_text',
         'value' => 'Hover over the toolbar buttons to see whether it is really in Korean!',
-        'editorOptions' => [
+        'editorOptions' => array(
             'lang' => 'ko',
-            'plugins' => ['fontfamily', 'textdirection']
-        ],
-    ]
+            'plugins' => array('fontfamily', 'textdirection')
+        ),
+    )
 );

--- a/src/userdoc/select2/574.php
+++ b/src/userdoc/select2/574.php
@@ -1,5 +1,5 @@
 <?php // Issue #574: multiselect inside form should send all selected elements
-echo CHtml::beginForm('/', 'post', ['id' => 'issue-574-checker-form']);
+echo CHtml::beginForm('/', 'post', array('id' => 'issue-574-checker-form'));
 $this->widget(
     'bootstrap.widgets.TbSelect2',
     array(

--- a/src/widgets/TbAlert.php
+++ b/src/widgets/TbAlert.php
@@ -17,10 +17,10 @@ Yii::import('booster.widgets.TbWidget');
  * @package booster.widgets.decoration
  */
 class TbAlert extends TbWidget {
-	
+
 	const CTX_ERROR = 'error';
 	const CTX_ERROR_CLASS = 'danger';
-	
+
 	/**
 	 * @var array The configuration for individual types of alerts.
 	 *
@@ -89,7 +89,7 @@ class TbAlert extends TbWidget {
 	 * Initializes the widget.
 	 */
 	public function init() {
-		
+
 		if (!isset($this->htmlOptions['id'])) {
 			$this->htmlOptions['id'] = $this->getId();
 		}
@@ -116,7 +116,7 @@ class TbAlert extends TbWidget {
 	 * Runs the widget.
 	 */
 	public function run() {
-		
+
 		$id = $this->htmlOptions['id'];
 
 		echo CHtml::openTag('div', $this->htmlOptions);
@@ -169,7 +169,7 @@ class TbAlert extends TbWidget {
 	 * @param $alertText
 	 */
 	protected function renderSingleAlert($alert, $context, $alertText) {
-		
+
 		$classes = array('alert in');
 
 		if (!isset($alert['fade'])) {
@@ -213,18 +213,18 @@ class TbAlert extends TbWidget {
 		echo $alertText;
 		echo CHtml::closeTag('div');
 	}
-	
+
 	/**
 	 * only these are allowed for alerts
 	 */
 	protected function isValidContext($context = false) {
-		return in_array($context, [
+		return in_array($context, array(
 			self::CTX_SUCCESS,
 			self::CTX_INFO,
 			self::CTX_WARNING,
 			self::CTX_DANGER,
 			self::CTX_ERROR,
-		]);
+		));
 	}
-	
+
 }

--- a/src/widgets/TbButton.php
+++ b/src/widgets/TbButton.php
@@ -6,7 +6,7 @@
  * @copyright Copyright &copy; Christoffer Niska 2011-
  * @license [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
  * @since 0.9.10
- * 
+ *
  * @author Amr Bedair <amr.bedair@gmail.com>
  * @since v4.0.0 - upgraded to bootstrap 3.1.1
  */
@@ -19,7 +19,7 @@ Yii::import('booster.widgets.TbWidget');
  * @package booster.widgets.forms.buttons
  */
 class TbButton extends TbWidget {
-	
+
 	// Button callback types.
 	const BUTTON_LINK = 'link';
 	const BUTTON_BUTTON = 'button';
@@ -42,13 +42,13 @@ class TbButton extends TbWidget {
 	const SIZE_DEFAULT = 'default';
 	const SIZE_SMALL = 'small';
 	const SIZE_EXTRA_SMALL = 'extra_small';
-	
-	protected static $sizeClasses = [
+
+	protected static $sizeClasses = array(
 		self::SIZE_LARGE => 'btn-lg',
 		self::SIZE_DEFAULT => '',
 		self::SIZE_SMALL => 'btn-sm',
 		self::SIZE_EXTRA_SMALL => 'btn-xs',
-	];
+	);
 
 	/**
 	 * @var string the button callback types.
@@ -152,14 +152,14 @@ class TbButton extends TbWidget {
      * @since 2.1.0
      */
     public $tooltipOptions = array();
-    
+
 	/**
 	 *### .init()
 	 *
 	 * Initializes the widget.
 	 */
 	public function init() {
-		
+
 		if (false === $this->visible) {
 			return;
 		}
@@ -171,9 +171,9 @@ class TbButton extends TbWidget {
 		}
 
 		$validSizes = array(
-			self::SIZE_LARGE, 
+			self::SIZE_LARGE,
 			self::SIZE_DEFAULT,
-			self::SIZE_SMALL, 
+			self::SIZE_SMALL,
 			self::SIZE_EXTRA_SMALL
 		);
 
@@ -289,11 +289,11 @@ class TbButton extends TbWidget {
 		if (false === $this->visible) {
 			return;
 		}
-		
+
 		if ($this->hasDropdown()) {
-			
+
 			echo $this->createButton();
-		
+
 			$this->controller->widget(
 				'booster.widgets.TbDropdown',
 				array(
@@ -316,7 +316,7 @@ class TbButton extends TbWidget {
 	 * @return string the created button.
 	 */
 	protected function createButton() {
-		
+
 		switch ($this->buttonType) {
 			case self::BUTTON_LINK:
 				return CHtml::link($this->label, $this->url, $this->htmlOptions);
@@ -353,26 +353,26 @@ class TbButton extends TbWidget {
 			case self::BUTTON_INPUTSUBMIT:
 				$this->htmlOptions['type'] = 'submit';
 				return CHtml::button($this->label, $this->htmlOptions);
-				
+
 			case self::BUTTON_TOGGLE_RADIO:
 				return $this->createToggleButton('radio');
-				
+
 			case self::BUTTON_TOGGLE_CHECKBOX:
 				return $this->createToggleButton('checkbox');
-				
+
 			default:
 			case self::BUTTON_BUTTON:
 				return CHtml::htmlButton($this->label, $this->htmlOptions);
 		}
 	}
-	
+
 	protected function createToggleButton($toggleType) {
-		
+
 		$html = '';
 		$html .= CHtml::openTag('label', $this->htmlOptions);
 		$html .= "<input type='{$toggleType}' name='{$this->id}_options' id='option_{$this->id}'> {$this->label}";
 		$html .= CHtml::closeTag('label');
-		
+
 		return $html;
 	}
 
@@ -384,7 +384,7 @@ class TbButton extends TbWidget {
 	 * @return bool the result.
 	 */
 	protected function hasDropdown() {
-		
+
 		return isset($this->items) && !empty($this->items);
 	}
 }

--- a/src/widgets/TbButtonGroup.php
+++ b/src/widgets/TbButtonGroup.php
@@ -4,9 +4,9 @@
  *
  * @author Christoffer Niska <ChristofferNiska@gmail.com>
  * @copyright Copyright &copy; Christoffer Niska 2011-
- * @license [New BSD License](http://www.opensource.org/licenses/bsd-license.php) 
+ * @license [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
  * @since 0.9.10
- * 
+ *
  * @author Amr Bedair <amr.bedair@gmail.com>
  * @since v4.0.0 - upgraded to bootstrap 3.1.1
  */
@@ -21,7 +21,7 @@ Yii::import('booster.widgets.TbButton');
  * @package booster.widgets.forms.buttons
  */
 class TbButtonGroup extends CWidget {
-	
+
 	// Toggle options.
 	const TOGGLE_CHECKBOX = 'checkbox';
 	const TOGGLE_RADIO = 'radio';
@@ -37,7 +37,7 @@ class TbButtonGroup extends CWidget {
 	 * @see BootButton::type
 	 */
 	public $context = TbButton::CTX_DEFAULT;
-	
+
 	/**
 	 * @var boolean indicates whether to use justified button groups
 	 */
@@ -89,9 +89,9 @@ class TbButtonGroup extends CWidget {
 	 * Initializes the widget.
 	 */
 	public function init() {
-		
-		$classes = [];
-		
+
+		$classes = array();
+
 		if ($this->stacked === true) {
 			$classes[] = 'btn-group-vertical';
 		} else {
@@ -101,7 +101,7 @@ class TbButtonGroup extends CWidget {
 		if ($this->dropup === true) {
 			$classes[] = 'dropup';
 		}
-		
+
 		if ($this->justified === true) {
 			$classes[] = 'btn-group-justified';
 		}
@@ -128,23 +128,23 @@ class TbButtonGroup extends CWidget {
 	 * Runs the widget.
 	 */
 	public function run() {
-		
+
 		echo CHtml::openTag('div', $this->htmlOptions);
 
 		foreach ($this->buttons as $button) {
 			if (isset($button['visible']) && $button['visible'] === false) {
 				continue;
 			}
-			
+
 			$validToggles = array(self::TOGGLE_CHECKBOX, self::TOGGLE_RADIO);
 			if (isset($this->toggle) && in_array($this->toggle, $validToggles)) {
 				$this->buttonType = $this->toggle;
 			}
-			
+
 			$justifiedNotLink = $this->justified && $this->buttonType !== TbButton::BUTTON_LINK;
 			if($justifiedNotLink)
 				echo '<div class="btn-group">';
-			
+
 			$this->controller->widget(
 				'booster.widgets.TbButton',
 				array(
@@ -165,7 +165,7 @@ class TbButtonGroup extends CWidget {
                     'tooltipOptions' => isset($button['tooltipOptions']) ? $button['tooltipOptions'] : array(),
 				)
 			);
-			
+
 			if($justifiedNotLink)
 				echo '</div>';
 		}

--- a/src/widgets/TbExtendedGridView.php
+++ b/src/widgets/TbExtendedGridView.php
@@ -4,7 +4,7 @@
  *
  * @author Antonio Ramirez <antonio@clevertech.biz>
  * @copyright Copyright &copy; Clevertech 2012-
- * @license [New BSD License](http://www.opensource.org/licenses/bsd-license.php) 
+ * @license [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
  */
 
 Yii::import('booster.widgets.TbGridView');
@@ -25,7 +25,7 @@ Yii::import('booster.widgets.TbGridView');
  * @package booster.widgets.grids
  */
 class TbExtendedGridView extends TbGridView {
-	
+
 	/**
 	 * @var bool $fixedHeader if set to true will keep the header fixed  position
 	 */
@@ -253,7 +253,7 @@ class TbExtendedGridView extends TbGridView {
 	public function renderKeys()
 	{
 		$data = $this->dataProvider->getData();
-		
+
 		if (!$this->sortableRows || (isset($data[0]) && !isset($data[0]->attributes[(string)$this->sortableAttribute]))) {
 			parent::renderKeys();
 		}
@@ -334,7 +334,7 @@ class TbExtendedGridView extends TbGridView {
 	 * Renders grid header
 	 */
 	public function renderTableHeader() {
-		
+
 		$this->renderChart();
 		parent::renderTableHeader();
 	}
@@ -374,7 +374,7 @@ class TbExtendedGridView extends TbGridView {
 	 *### .renderBulkActions()
 	 */
 	public function renderBulkActions() {
-		
+
         Booster::getBooster()->registerAssetJs('jquery.saveselection.gridview.js');
         $this->componentsAfterAjaxUpdate[] = "$.fn.yiiGridView.afterUpdateGrid('".$this->id."');";
 		echo '<tr><td colspan="' . count($this->columns) . '">';
@@ -390,7 +390,7 @@ class TbExtendedGridView extends TbGridView {
 	 * @throws CException
 	 */
 	public function renderChart() {
-		
+
 		if (!$this->displayChart || $this->dataProvider->getItemCount() <= 0) {
 			return;
 		}
@@ -454,7 +454,7 @@ class TbExtendedGridView extends TbGridView {
 			}
 			return false;
 		});';
-		
+
 		$this->componentsAfterAjaxUpdate[] = '
 			if($("label.grid.'.$this->getId().'-grid-control").hasClass("active")) {
 				$("#' . $this->getId() . ' #' . $chartId . '").hide();
@@ -492,8 +492,8 @@ class TbExtendedGridView extends TbGridView {
 			++$cnt;
 		}
 
-		$xAxisData = [];
-		
+		$xAxisData = array();
+
 		$xAxisData[] = array('categories'=>array());
 		if(!empty($this->chartOptions['data']['xAxis'])){
 			$xAxis = $this->chartOptions['data']['xAxis'];
@@ -515,7 +515,7 @@ class TbExtendedGridView extends TbGridView {
 				}
 			}
 		}
-		
+
 		// ****************************************
 		// render chart
 		$options = CMap::mergeArray(
@@ -524,13 +524,13 @@ class TbExtendedGridView extends TbGridView {
 		);
 		$this->chartOptions['htmlOptions'] = isset($this->chartOptions['htmlOptions'])
 			? $this->chartOptions['htmlOptions'] : array();
-		
+
 		// sorry but use a class to provide styles, we need this
 		if(empty($this->chartOptions['htmlOptions']['style']))
 			$this->chartOptions['htmlOptions']['style'] = 'width: 100%; height: 100%;';
 		else
 			$this->chartOptions['htmlOptions']['style'] = $this->chartOptions['htmlOptions']['style'].'; width: 100%; height: 100%;';
-		
+
 		// build unique ID
 		// important!
 		echo '<div>';
@@ -549,7 +549,7 @@ class TbExtendedGridView extends TbGridView {
 			echo "<div id='{$chartId}' " . CHtml::renderAttributes(
 				$this->chartOptions['htmlOptions']
 			) . " data-config='{$jsOptions}'></div>";
-			
+
 			/* fix for chart dimensions changing after ajax */
 			$this->componentsAfterAjaxUpdate[] = "
 				$('#".$chartId."').width($('#".$this->id." table').width());
@@ -569,7 +569,7 @@ class TbExtendedGridView extends TbGridView {
 		echo '</div>';
 		// end chart display
 		// ****************************************
-		
+
 		// check if the chart should appear by default
 		if(isset($this->chartOptions['defaultView']) && $this->chartOptions['defaultView'] === true) {
 			$this->componentsReadyScripts[] = '
@@ -1215,7 +1215,7 @@ class TbPercentOfTypeGooglePieOperation extends TbPercentOfTypeOperation
 	 * @return mixed|void
 	 */
 	public function displaySummary() {
-		
+
 		$this->data[] = array('Label', 'Percent');
 
 		foreach ($this->types as $type) {

--- a/src/widgets/TbProgress.php
+++ b/src/widgets/TbProgress.php
@@ -16,7 +16,7 @@ Yii::import('booster.widgets.TbWidget');
  * @since 0.9.10
  */
 class TbProgress extends TbWidget {
-	
+
 	/**
 	 * @var boolean indicates whether the bar is striped.
 	 */
@@ -56,20 +56,20 @@ class TbProgress extends TbWidget {
 
 	protected $progressClasses = array('progress');
 	protected $progressBarClasses = array('progress-bar');
-	
+
 	/**
 	 *### .init()
 	 *
 	 * Initializes the widget.
 	 */
 	public function init() {
-		
+
 		if ($this->isValidContext())
 			$this->progressBarClasses[] = 'progress-bar-' . $this->getContextClass();
-		
+
 		if ($this->striped)
 			$this->progressClasses[] = 'progress-striped';
-		
+
 		if ($this->animated)
 			$this->progressClasses[] = 'active';
 
@@ -96,7 +96,7 @@ class TbProgress extends TbWidget {
 	 * Updated to use stacked progress bars
 	 */
 	public function run() {
-		
+
 		echo CHtml::openTag('div', $this->htmlOptions);
 		if (empty($this->stacked)) {
 			echo '<div class="'.implode(' ', $this->progressBarClasses).'" style="width: ' . $this->percent . '%;">' . $this->content . '</div>';
@@ -122,13 +122,13 @@ class TbProgress extends TbWidget {
 		}
 		echo CHtml::closeTag('div');
 	}
-	
+
 	protected function isValidContext($context = false) {
-		return in_array($this->context, [
-			self::CTX_SUCCESS, 
-			self::CTX_INFO, 
-			self::CTX_WARNING, 
+		return in_array($this->context, array(
+			self::CTX_SUCCESS,
+			self::CTX_INFO,
+			self::CTX_WARNING,
 			self::CTX_DANGER
-		]);
+		));
 	}
 }


### PR DESCRIPTION
Removed short array syntax (PHP 5.4+)
Issue #877

Sorry, also looks like I trimmed trailing spaces on the edited files.
