### PR TITLE
Fix Bug with datetimepicker

### DIFF
--- a/src/widgets/TbEditable.php
+++ b/src/widgets/TbEditable.php
@@ -567,7 +567,7 @@ class TbEditable extends CWidget
             $widget = Yii::app()->widgetFactory->createWidget(
                 $this->getOwner(),
                 'bootstrap.widgets.TbDateTimePicker',
-                array('options' => $this->options['datetimepicker'])
+                array('options' => $this->options['datepicker'])
             );
             $widget->registerLanguageScript();
         }


### PR DESCRIPTION
This fixes the bug, when using datetime as editable in a TbExtendedGridView then it fails with the error "Undefined index: datetimepicker".
By changing datetimepicker to datepicker everythings works fine.
