### PR TITLE
Add support for rowHtmlOptionsExpression from Yii 1.1.13 to renderTableRow()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Thank you all
 Antonio Ramirez.
 
 ## YiiBooster latest development alpha
+- **(fix)** fix TbGroupGridView support for rowHtmlOptionsExpression #920
 -
   
 ## YiiBooster version 4.1.0

--- a/src/widgets/TbGroupGridView.php
+++ b/src/widgets/TbGroupGridView.php
@@ -281,19 +281,34 @@ class TbGroupGridView extends TbGridView
 		}
 
 		// original CGridView code
-		if ($this->rowCssClassExpression !== null) {
+		$htmlOptions = array();
+		if ($this->rowHtmlOptionsExpression !== null) {
 			$data = $this->dataProvider->data[$row];
-			echo '<tr class="' . $this->evaluateExpression(
-				$this->rowCssClassExpression,
+			$options = $this->evaluateExpression(
+				$this->rowHtmlOptionsExpression,
 				array('row' => $row, 'data' => $data)
-			) . '">';
-		} else if (is_array($this->rowCssClass) && ($n = count($this->rowCssClass)) > 0) {
-			echo '<tr class="' . $this->rowCssClass[$row % $n] . '">';
-		} else {
-			echo '<tr>';
+			);
+			if (is_array($options)) {
+				$htmlOptions = $options;
+			}
 		}
 
+		if ($this->rowCssClassExpression !== null) {
+			$data = $this->dataProvider->data[$row];
+			$class = $this->evaluateExpression($this->rowCssClassExpression, array('row' => $row, 'data' => $data));
+		} elseif (is_array($this->rowCssClass) && ($n = count($this->rowCssClass)) > 0) {
+			$class = $this->rowCssClass[$row % $n];
+		}
 
+		if (!empty($class)) {
+			if (isset($htmlOptions['class'])) {
+				$htmlOptions['class'] .= ' ' . $class;
+			} else {
+				$htmlOptions['class'] = $class;
+			}
+		}
+
+		echo CHtml::openTag('tr', $htmlOptions);
 		if (!$this->_changes) { //standart CGridview's render
 			foreach ($this->columns as $column) {
 				$column->renderDataCell($row);


### PR DESCRIPTION
rowHtmlOptionsExpression support from yii 1.1.13 was not added to TbGroupGridView. This PR fixes that.