### PR TITLE
 fix to create link styled as a button 

### DIFF
--- a/src/widgets/TbButton.php
+++ b/src/widgets/TbButton.php
@@ -169,10 +169,6 @@ class TbButton extends TbWidget {
 		if ($this->isValidContext()) {
 			$classes[] = 'btn-' . $this->getContextClass();
 		}
-		
-		if($this->buttonType == self::BUTTON_LINK) {
-			$classes[] = 'btn-link';
-		}
 
 		$validSizes = array(
 			self::SIZE_LARGE, 

--- a/src/widgets/TbWidget.php
+++ b/src/widgets/TbWidget.php
@@ -51,8 +51,8 @@ abstract class TbWidget extends CWidget {
 	 * 
 	 * @param string $context
 	 */
-	protected function isValidContext($cotext = false) {
-		if($cotext)
+	protected function isValidContext($context = false) {
+		if($context)
 			return defined(get_called_class().'::CTX_'.strtoupper($context));
 		else
 			return defined(get_called_class().'::CTX_'.strtoupper($this->context));


### PR DESCRIPTION
To style a button like a link, `context` should be used, not `buttonType` - currently there is no way to get a link styled like a button (anchor tag without form)

http://getbootstrap.com/css/#buttons
