### PR TITLE
Set type of the TbMenu to navbar for TbNavbar if not set already!

### DIFF
--- a/src/widgets/TbNavbar.php
+++ b/src/widgets/TbNavbar.php
@@ -163,6 +163,10 @@ class TbNavbar extends CWidget {
 			if (is_string($item)) {
 				echo $item;
 			} else {
+				if (!isset($item['type'])) {
+					$item['type'] = 'navbar';
+				}
+				
 				if (isset($item['class'])) {
 					$className = $item['class'];
 					unset($item['class']);


### PR DESCRIPTION
If it's not set in the configuration array like shown in the user examples, the navbar will miss a css class which destroy's the layout
