### PR TITLE
capsulate yiiEditable to prevent rebinding of ajaxUpdate.editable event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Thank you all
 Antonio Ramirez.
 
 ## YiiBooster latest development alpha
--
+- **(fix)** fix editable events from being reregistered by yiiEditable() #954
   
 ## YiiBooster version 4.1.0
 - **(enh)** upgarde to Bootstrap 3.2.0 - #882

--- a/src/widgets/TbEditable.php
+++ b/src/widgets/TbEditable.php
@@ -521,7 +521,7 @@ class TbEditable extends CWidget
         //wrap in anonymous function for live update
         if($this->liveTarget) {
             $script2 = "\n$('body').on('ajaxUpdate.editable',function(e){ if(e.target.id == '".$this->liveTarget."') yiiEditable2(); });";
-            $script = "(function yiiEditable() {function yiiEditable2() {\n\t$script\n} $script2 }\n());";
+            $script = "(function yiiEditable() {function yiiEditable2() {\n\t$script\n} $script2 yiiEditable2(); }\n());";
         }
         
         Yii::app()->getClientScript()->registerScript(__CLASS__ . '-' . $selector, $script);

--- a/src/widgets/TbEditable.php
+++ b/src/widgets/TbEditable.php
@@ -520,8 +520,8 @@ class TbEditable extends CWidget
 
         //wrap in anonymous function for live update
         if($this->liveTarget) {
-            $script .= "\n $('body').on('ajaxUpdate.editable', function(e){ if(e.target.id == '".$this->liveTarget."') yiiEditable(); });";
-            $script = "(function yiiEditable() {\n ".$script."\n}());";
+            $script2 = "\n$('body').on('ajaxUpdate.editable',function(e){ if(e.target.id == '".$this->liveTarget."') yiiEditable2(); });";
+            $script = "(function yiiEditable() {function yiiEditable2() {\n\t$script\n} $script2 }\n());";
         }
         
         Yii::app()->getClientScript()->registerScript(__CLASS__ . '-' . $selector, $script);


### PR DESCRIPTION
every time yiiEditable is called, the function registers the handler for ajaxUpdate.editable.
splitting the registration from yiiEditable prevents this.