### PR TITLE
Typeahead support for multiple and bloodhound

### DIFF
--- a/src/widgets/TbTypeahead.php
+++ b/src/widgets/TbTypeahead.php
@@ -21,7 +21,7 @@
 
 Yii::import('booster.widgets.TbBaseInputWidget');
 
-class TbTypeahead2 extends TbBaseInputWidget {
+class TbTypeahead extends TbBaseInputWidget {
 	
 	/**
 	 * @var array the options for the twitter typeahead widget


### PR DESCRIPTION
With this modifications you can declare multiple datasets and they can be Bloodhound datasets as well (by giving to the source array a 'name').
Examples of the datasets configuration:

```
'datasets' => array(
    array(
        'source' => array(
            'name' => 'Ajax source',
            'datumTokenizer' => "js:Bloodhound.tokenizers.obj.whitespace('value')",
            'queryTokenizer' => "js:Bloodhound.tokenizers.whitespace",
            'remote' => '/index.php?r=site/lookFor&term=%QUERY'
        ),
    ),
    array(
        'source' => array('Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California',
            'Colorado', 'Connecticut', 'Delaware', 'Florida', 'Georgia',
            'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas',
            'Kentucky', 'Louisiana', 'Maine', 'Maryland', 'Massachusetts',
            'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana',
            'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey',
            'New Mexico', 'New York', 'North Dakota', 'North Carolina',
            'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania', 'Rhode Island',
            'South Carolina', 'South Dakota', 'Tennessee', 'Texas',
            'Utah', 'Vermont', 'Virginia', 'Washington', 'West Virginia',
            'Wisconsin', 'Wyoming'
        ),
    )
),
```

or for one dataset:

```
'datasets' => array(
    'source' => array(
        'name' => 'Ajax source',
        'datumTokenizer' => "js:Bloodhound.tokenizers.obj.whitespace('value')",
        'queryTokenizer' => "js:Bloodhound.tokenizers.whitespace",
        'remote' => '/index.php?r=site/lookFor&term=%QUERY'
    ),
),
```
