### PR TITLE
Fix 'uncheckValue' in htmlOptions (for methods activeRadioButtonList and activeCheckBoxList)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Antonio Ramirez.
 - **(enh)** Added support to TbActiveForm to use TbChosen widget (YaroslavMolchan)
 - **(fix)** fix editable events from being reregistered by yiiEditable() #954
 - **(fix)** fix TbGroupGridView support for rowHtmlOptionsExpression #920
+- **(fix)** fix methods TbHtml::activeRadioButtonList and TbHtml::activeCheckBoxList for the case $htmlOptions = ['uncheckValue' => null] #917 (IStranger/G.Azamat)
   
 ## YiiBooster version 4.1.0
 - **(enh)** upgarde to Bootstrap 3.2.0 - #882

--- a/src/helpers/TbHtml.php
+++ b/src/helpers/TbHtml.php
@@ -1699,7 +1699,7 @@ EOD;
         parent::resolveNameID($model, $attribute, $htmlOptions);
         $selection = parent::resolveValue($model, $attribute);
         $name = TbArray::popValue('name', $htmlOptions);
-        $uncheckValue = isset($htmlOptions['uncheckValue']) ? TbArray::popValue('uncheckValue', $htmlOptions) : '';
+        $uncheckValue = array_key_exists('uncheckValue', $htmlOptions) ? TbArray::popValue('uncheckValue', $htmlOptions) : '';
         $hiddenOptions = isset($htmlOptions['id']) ? array('id' => parent::ID_PREFIX . $htmlOptions['id']) : array('id' => false);
         $hidden = isset($uncheckValue) ? parent::hiddenField($name, $uncheckValue, $hiddenOptions) : '';
         return $hidden . self::radioButtonList($name, $selection, $data, $htmlOptions);
@@ -1735,7 +1735,7 @@ EOD;
             parent::addErrorCss($htmlOptions);
         }
         $name = TbArray::popValue('name', $htmlOptions);
-        $uncheckValue = isset($htmlOptions['uncheckValue']) ? TbArray::popValue('uncheckValue', $htmlOptions) : '';
+        $uncheckValue = array_key_exists('uncheckValue', $htmlOptions) ? TbArray::popValue('uncheckValue', $htmlOptions) : '';
         $hiddenOptions = isset($htmlOptions['id']) ? array('id' => parent::ID_PREFIX . $htmlOptions['id']) : array('id' => false);
         $hidden = isset($uncheckValue) ? parent::hiddenField($name, $uncheckValue, $hiddenOptions) : '';
         return $hidden . self::checkBoxList($name, $selection, $data, $htmlOptions);


### PR DESCRIPTION
fix methods TbHtml::activeRadioButtonList and TbHtml::activeCheckBoxList for the case 
$htmlOptions = ['uncheckValue' => null] 
see #917
