### PR TITLE
"Failed render" issue solved for Select2 and Switch.

### DIFF
--- a/src/widgets/TbSelect2.php
+++ b/src/widgets/TbSelect2.php
@@ -1,6 +1,7 @@
 <?php
+
 /**
- *##  TbSelect2 class file.
+ * ##  TbSelect2 class file.
  *
  * @author Antonio Ramirez <antonio@clevertech.biz>
  * @copyright Copyright &copy; Clevertech 2012-
@@ -8,20 +9,21 @@
  */
 
 /**
- *## Select2 wrapper widget
+ * ## Select2 wrapper widget
  *
  * @see http://ivaynberg.github.io/select2/
  *
  * @package booster.widgets.forms.inputs
  */
 class TbSelect2 extends CInputWidget {
-	
+
 	/**
 	 * @var TbActiveForm when created via TbActiveForm.
 	 * This attribute is set to the form that renders the widget
 	 * @see TbActionForm->inputRow
 	 */
 	public $form;
+
 	/**
 	 * @var array @param data for generating the list options (value=>display)
 	 */
@@ -47,25 +49,24 @@ class TbSelect2 extends CInputWidget {
 	 */
 	public $options;
 
-    /**
-     * @var bool
-     * @since 2.1.0
-     */
-    public $readonly = false;
-
-    /**
-     * @var bool
-     * @since 2.1.0
-     */
-    public $disabled = false;
+	/**
+	 * @var bool
+	 * @since 2.1.0
+	 */
+	public $readonly = false;
 
 	/**
-	 *### .init()
+	 * @var bool
+	 * @since 2.1.0
+	 */
+	public $disabled = false;
+
+	/**
+	 * ### .init()
 	 *
 	 * Initializes the widget.
 	 */
-	public function init()
-	{
+	public function init() {
 		$this->normalizeData();
 
 		$this->normalizeOptions();
@@ -74,44 +75,36 @@ class TbSelect2 extends CInputWidget {
 
 		$this->setDefaultWidthIfEmpty();
 
-        // disabled & readonly
-        if (!empty($this->htmlOptions['readonly'])) {
-            $this->readonly = true;
-        }
-        if (!empty($this->htmlOptions['disabled'])) {
-            $this->disabled = true;
-        }
+		// disabled & readonly
+		if (!empty($this->htmlOptions['readonly'])) {
+			$this->readonly = true;
+		}
+		if (!empty($this->htmlOptions['disabled'])) {
+			$this->disabled = true;
+		}
 	}
 
 	/**
-	 *### .run()
+	 * ### .run()
 	 *
 	 * Runs the widget.
 	 */
-	public function run()
-	{
+	public function run() {
 		list($name, $id) = $this->resolveNameID();
 
 		if ($this->hasModel()) {
 			if ($this->form) {
-				echo $this->asDropDownList
-					?
-					$this->form->dropDownList($this->model, $this->attribute, $this->data, $this->htmlOptions)
-					:
+				echo $this->asDropDownList ?
+					$this->form->dropDownList($this->model, $this->attribute, $this->data, $this->htmlOptions) :
 					$this->form->hiddenField($this->model, $this->attribute, $this->htmlOptions);
 			} else {
-				echo $this->asDropDownList
-					?
-					CHtml::activeDropDownList($this->model, $this->attribute, $this->data, $this->htmlOptions)
-					:
+				echo $this->asDropDownList ?
+					CHtml::activeDropDownList($this->model, $this->attribute, $this->data, $this->htmlOptions) :
 					CHtml::activeHiddenField($this->model, $this->attribute, $this->htmlOptions);
 			}
-
 		} else {
-			echo $this->asDropDownList
-				?
-				CHtml::dropDownList($name, $this->value, $this->data, $this->htmlOptions)
-				:
+			echo $this->asDropDownList ?
+				CHtml::dropDownList($name, $this->value, $this->data, $this->htmlOptions) :
 				CHtml::hiddenField($name, $this->value, $this->htmlOptions);
 		}
 
@@ -119,7 +112,7 @@ class TbSelect2 extends CInputWidget {
 	}
 
 	/**
-	 *### .registerClientScript()
+	 * ### .registerClientScript()
 	 *
 	 * Registers required client script for bootstrap select2. It is not used through bootstrap->registerPlugin
 	 * in order to attach events if any
@@ -129,32 +122,30 @@ class TbSelect2 extends CInputWidget {
 	 * @throws CException
 	 */
 	public function registerClientScript($id) {
-		
-        Booster::getBooster()->registerPackage('select2');
+
+		Booster::getBooster()->registerPackage('select2');
 
 		$options = !empty($this->options) ? CJavaScript::encode($this->options) : '';
 
-		if(! empty($this->val)) {
-			if(is_array($this->val)) {
+		if (!empty($this->val)) {
+			if (is_array($this->val)) {
 				$data = CJSON::encode($this->val);
 			} else {
 				$data = $this->val;
 			}
 
 			$defValue = ".select2('val', $data)";
-		}
-		else
+		} else
 			$defValue = '';
 
-        if ($this->readonly) {
-            $defValue .= ".select2('readonly', true)";
-        }
-        elseif ($this->disabled) {
-            $defValue .= ".select2('enable', false)";
-        }
+		if ($this->readonly) {
+			$defValue .= ".select2('readonly', true)";
+		} elseif ($this->disabled) {
+			$defValue .= ".select2('enable', false)";
+		}
 
 		ob_start();
-		echo "jQuery('#{$id}').select2({$options})";
+		echo "jQuery('select#{$id}').select2({$options})";
 		foreach ($this->events as $event => $handler) {
 			echo ".on('{$event}', " . CJavaScript::encode($handler) . ")";
 		}
@@ -163,21 +154,18 @@ class TbSelect2 extends CInputWidget {
 		Yii::app()->getClientScript()->registerScript(__CLASS__ . '#' . $this->getId(), ob_get_clean() . ';');
 	}
 
-	private function setDefaultWidthIfEmpty()
-	{
+	private function setDefaultWidthIfEmpty() {
 		if (empty($this->options['width'])) {
 			$this->options['width'] = 'resolve';
 		}
 	}
 
-	private function normalizeData()
-	{
+	private function normalizeData() {
 		if (!$this->data)
 			$this->data = array();
 	}
 
-	private function addEmptyItemIfPlaceholderDefined()
-	{
+	private function addEmptyItemIfPlaceholderDefined() {
 		if (!empty($this->htmlOptions['placeholder']))
 			$this->options['placeholder'] = $this->htmlOptions['placeholder'];
 
@@ -185,15 +173,14 @@ class TbSelect2 extends CInputWidget {
 			$this->prependDataWithEmptyItem();
 	}
 
-	private function normalizeOptions()
-	{
+	private function normalizeOptions() {
 		if (empty($this->options)) {
 			$this->options = array();
 		}
 	}
 
-	private function prependDataWithEmptyItem()
-	{
+	private function prependDataWithEmptyItem() {
 		$this->data = array('' => '') + $this->data;
 	}
+
 }

--- a/src/widgets/TbSwitch.php
+++ b/src/widgets/TbSwitch.php
@@ -71,11 +71,16 @@ class TbSwitch extends CInputWidget {
 
         $booster = Booster::getBooster();
         $booster->registerPackage('switch');
+		/*
+		 * Hacked by Babak
+		 * Original code: $config = CJavaScript::encode($this->options);
+		 * This is a hack to help transfer the onText and offText
+		 * So put them in the htmlOptions 
+		 */
+		$config = CJavaScript::encode(count($this->options)?$this->options:$this->htmlOptions);
 
-		$config = CJavaScript::encode($this->options);
-		
 		ob_start();
-		echo "$('#$id').bootstrapSwitch({$config})";
+		echo "$('input#$id').bootstrapSwitch({$config})";
 		foreach ($this->events as $event => $handler) {
 			$event = $event.'.bootstrapSwitch';
 			if (!$handler instanceof CJavaScriptExpression && strpos($handler, 'js:') === 0)

--- a/src/widgets/TbSwitch.php
+++ b/src/widgets/TbSwitch.php
@@ -9,10 +9,10 @@
  *## Class TbToggleButton
  * @see <http://www.bootstrap-switch.org/>
  * @package booster.widgets.forms.buttons
- * 
+ *
  */
 class TbSwitch extends CInputWidget {
-	
+
 	/**
 	 * @var TbActiveForm when created via TbActiveForm, this attribute is set to the form that renders the widget
 	 * @see TbActionForm->inputRow
@@ -34,7 +34,7 @@ class TbSwitch extends CInputWidget {
 	 * </pre>
 	 */
 	public $events = array();
-	
+
 	/**
 	 * js widget options
 	 * @see <http://www.bootstrap-switch.org/> options part
@@ -46,7 +46,7 @@ class TbSwitch extends CInputWidget {
 	 * Widget's run function
 	 */
 	public function run() {
-		
+
 		list($name, $id) = $this->resolveNameID();
 
 		if ($this->hasModel()) {
@@ -71,13 +71,7 @@ class TbSwitch extends CInputWidget {
 
         $booster = Booster::getBooster();
         $booster->registerPackage('switch');
-		/*
-		 * Hacked by Babak
-		 * Original code: $config = CJavaScript::encode($this->options);
-		 * This is a hack to help transfer the onText and offText
-		 * So put them in the htmlOptions 
-		 */
-		$config = CJavaScript::encode(count($this->options)?$this->options:$this->htmlOptions);
+		$config = CJavaScript::encode($this->options);
 
 		ob_start();
 		echo "$('input#$id').bootstrapSwitch({$config})";


### PR DESCRIPTION
Select2 and Switch field were detected to fail when rendered in partials.
This issue is solved by adding "input" to the Switch's CSS selector:

```php
echo "$('input#$id').bootstrapSwitch({$config})";
```

I have also made changes to the initialization of the options. If the `$this->options` !isset then the `$this->htmlOptions` is examined and encoded as the options for the `$('input#$id').bootstrapSwitch({$config})` call. This issue arised because the `onText` and `offText` of the Switch could not be set.
(Of course it can be set. One should just know how)

the last (the third) options looks like this, but it is not written anywhere,

```php
[
    'widgetOptions' => [
        'htmlOptions' => [],
        'options' => [
            'onText' => 'Yes',
            'offText' => 'No',
        ],
        'events' => []
    ]
]
```

and 

https://stackoverflow.com/questions/14483348/query-function-not-defined-for-select2-undefined-error

The issue is also solved in the `TbSelect2` by adding `"select"`  to the Select2's CSS selector:

```php
echo "jQuery('select#{$id}').select2({$options})";
```